### PR TITLE
feat: self-hosted hasura for DataLayer graphql API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ DATALAYER_PG_DATABASE=datalayer-postgres
 DATALAYER_POSTGRES_EXPOSED_PORT=5434
 
 ######################################################
-############### DATALAYER HASURA API ###################
+############### DATALAYER HASURA API #################
 ######################################################
+#for reference on Hasura configuration, see: https://hasura.io/docs/2.0/deployment/graphql-engine-flags/reference/
 DATALAYER_HASURA_EXPOSED_PORT=8082
 DATALAYER_HASURA_ENABLE_CONSOLE=true
 DATALAYER_HASURA_ADMIN_SECRET=my-admin-secret
@@ -18,6 +19,7 @@ DATALAYER_HASURA_ENABLE_TELEMETRY=false
 # HASURA_GRAPHQL_METADATA_DATABASE_EXTENSIONS_SCHEMA: "chain_data_schema_1"
 ## enable debugging mode. It is recommended to disable this in production
 DATALAYER_HASURA_DEV_MODE=true
+DATALAYER_HASURA_ADMIN_INTERNAL_ERRORS=true
 ## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
 # HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
 

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DATALAYER_POSTGRES_EXPOSED_PORT=5434
 ######################################################
 ############### DATALAYER HASURA API ###################
 ######################################################
+DATALAYER_HASURA_EXPOSED_PORT=8082
 DATALAYER_HASURA_ENABLE_CONSOLE=true
 DATALAYER_HASURA_ADMIN_SECRET=my-admin-secret
 DATALAYER_HASURA_UNAUTHORIZED_ROLE=public

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,19 @@ DATALAYER_PG_USER=postgres
 DATALAYER_PG_DATABASE=datalayer-postgres
 DATALAYER_POSTGRES_EXPOSED_PORT=5434
 
+######################################################
+############### DATALAYER HASURA API ###################
+######################################################
+DATALAYER_HASURA_ENABLE_CONSOLE=true
+DATALAYER_HASURA_ADMIN_SECRET=my-admin-secret
+DATALAYER_HASURA_UNAUTHORIZED_ROLE=public
+DATALAYER_HASURA_CORS_DOMAIN=*
+DATALAYER_HASURA_ENABLE_TELEMETRY=false
+# HASURA_GRAPHQL_METADATA_DATABASE_EXTENSIONS_SCHEMA: "chain_data_schema_1"
+## enable debugging mode. It is recommended to disable this in production
+DATALAYER_HASURA_DEV_MODE=true
+## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
+# HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
 
 ############################################################
 ############### ENVIO POSTGRES & INDEXER ###################

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     api-hasura:
         image: hasura/graphql-engine:latest
         ports:
-            - "8082:8080"
+            - "${DATALAYER_HASURA_EXPOSED_PORT:-8082}:8080"
         restart: always
         env_file:
             - .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,49 @@ services:
             POSTGRES_PASSWORD: ${DATALAYER_POSTGRES_PASSWORD}
         networks:
             - datalayer
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U ${DATALAYER_PG_USER}"]
+            interval: 5s
+            timeout: 5s
+            retries: 5
+
+    api-hasura:
+        image: hasura/graphql-engine:latest
+        ports:
+            - "8082:8080"
+        restart: always
+        env_file:
+            - .env
+        environment:
+            HASURA_GRAPHQL_DATABASE_URL: postgres://${DATALAYER_PG_USER}:${DATALAYER_POSTGRES_PASSWORD}@datalayer-postgres:5432/${DATALAYER_PG_DATABASE}
+            HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://${DATALAYER_PG_USER}:${DATALAYER_POSTGRES_PASSWORD}@datalayer-postgres:5432/${DATALAYER_PG_DATABASE}
+            HASURA_GRAPHQL_ENABLE_CONSOLE: ${DATALAYER_HASURA_ENABLE_CONSOLE:-true}
+            HASURA_GRAPHQL_ADMIN_SECRET: ${DATALAYER_HASURA_ADMIN_SECRET:-secret}
+            HASURA_GRAPHQL_UNAUTHORIZED_ROLE: ${DATALAYER_HASURA_UNAUTHORIZED_ROLE:-public}
+            HASURA_GRAPHQL_CORS_DOMAIN: ${DATALAYER_HASURA_CORS_DOMAIN:-*}
+            HASURA_GRAPHQL_ENABLE_TELEMETRY: ${DATALAYER_HASURA_ENABLE_TELEMETRY:-false}
+            HASURA_GRAPHQL_EXPERIMENTAL_FEATURES: bigquery_string_numeric_input
+            HASURA_GRAPHQL_BIGQUERY_STRING_NUMERIC_INPUT: true
+            # HASURA_GRAPHQL_METADATA_DATABASE_EXTENSIONS_SCHEMA: ${DATALAYER_HASURA_METADATA_DATABASE_EXTENSIONS_SCHEMA:-chain_data_schema_1}
+            ## enable debugging mode. It is recommended to disable this in production
+            HASURA_GRAPHQL_DEV_MODE: ${DATALAYER_HASURA_DEV_MODE:-true}
+            HASURA_GRAPHQL_ENABLED_LOG_TYPES: "startup, http-log, webhook-log, websocket-log, query-log"
+            HASURA_GRAPHQL_ENABLED_APIS: "graphql,metrics"
+            HASURA_GRAPHQL_ADMIN_INTERNAL_ERRORS: "true"
+            ## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
+            # HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
+        depends_on:
+            datalayer-postgres:
+                condition: service_healthy
+        healthcheck:
+            test: timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1
+            interval: 5s
+            timeout: 2s
+            retries: 50
+            start_period: 5s
+        networks:
+            - datalayer
+
     envio-postgres:
         image: postgres:16
         restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
             retries: 5
 
     api-hasura:
-        image: hasura/graphql-engine:latest
+        image: hasura/graphql-engine:v2.44.0
         ports:
             - "${DATALAYER_HASURA_EXPOSED_PORT:-8082}:8080"
         restart: always
@@ -42,7 +42,7 @@ services:
             HASURA_GRAPHQL_DEV_MODE: ${DATALAYER_HASURA_DEV_MODE:-true}
             HASURA_GRAPHQL_ENABLED_LOG_TYPES: "startup, http-log, webhook-log, websocket-log, query-log"
             HASURA_GRAPHQL_ENABLED_APIS: "graphql,metrics"
-            HASURA_GRAPHQL_ADMIN_INTERNAL_ERRORS: "true"
+            HASURA_GRAPHQL_ADMIN_INTERNAL_ERRORS: ${DATALAYER_HASURA_ADMIN_INTERNAL_ERRORS:-true}
             ## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
             # HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
         depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 services:
-    datalayer-postgres:
+    datalayer-postgres-db:
         image: postgres:16
         restart: always
         ports:
@@ -20,7 +20,7 @@ services:
             timeout: 5s
             retries: 5
 
-    api-hasura:
+    datalayer-graphql-api:
         image: hasura/graphql-engine:v2.44.0
         ports:
             - "${DATALAYER_HASURA_EXPOSED_PORT:-8082}:8080"
@@ -28,8 +28,8 @@ services:
         env_file:
             - .env
         environment:
-            HASURA_GRAPHQL_DATABASE_URL: postgres://${DATALAYER_PG_USER}:${DATALAYER_POSTGRES_PASSWORD}@datalayer-postgres:5432/${DATALAYER_PG_DATABASE}
-            HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://${DATALAYER_PG_USER}:${DATALAYER_POSTGRES_PASSWORD}@datalayer-postgres:5432/${DATALAYER_PG_DATABASE}
+            HASURA_GRAPHQL_DATABASE_URL: postgres://${DATALAYER_PG_USER}:${DATALAYER_POSTGRES_PASSWORD}@datalayer-postgres-db:5432/${DATALAYER_PG_DATABASE}
+            HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://${DATALAYER_PG_USER}:${DATALAYER_POSTGRES_PASSWORD}@datalayer-postgres-db:5432/${DATALAYER_PG_DATABASE}
             HASURA_GRAPHQL_ENABLE_CONSOLE: ${DATALAYER_HASURA_ENABLE_CONSOLE:-true}
             HASURA_GRAPHQL_ADMIN_SECRET: ${DATALAYER_HASURA_ADMIN_SECRET:-secret}
             HASURA_GRAPHQL_UNAUTHORIZED_ROLE: ${DATALAYER_HASURA_UNAUTHORIZED_ROLE:-public}
@@ -46,7 +46,7 @@ services:
             ## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
             # HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
         depends_on:
-            datalayer-postgres:
+            datalayer-postgres-db:
                 condition: service_healthy
         healthcheck:
             test: timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1
@@ -57,7 +57,7 @@ services:
         networks:
             - datalayer
 
-    envio-postgres:
+    indexer-postgres-db:
         image: postgres:16
         restart: always
         ports:
@@ -71,14 +71,14 @@ services:
             POSTGRES_USER: ${ENVIO_PG_USER}
             POSTGRES_PASSWORD: ${ENVIO_POSTGRES_PASSWORD}
         networks:
-            - indexer-service
-    graphql-engine:
+            - indexer
+    indexer-graphql-api:
         image: hasura/graphql-engine:v2.23.0
         ports:
             - "${HASURA_EXPOSED_PORT:-8080}:${PORT:-8080}"
         user: 1001:1001
         depends_on:
-            - "envio-postgres"
+            - "indexer-postgres-db"
         restart: always
         env_file:
             - .env
@@ -89,24 +89,25 @@ services:
             retries: 50
             start_period: 5s
         networks:
-            - indexer-service
-    indexer-service:
+            - indexer
+    indexer:
         build:
             context: ./apps/indexer
             dockerfile: Dockerfile
         depends_on:
-            - "envio-postgres"
-            - "graphql-engine"
+            - "indexer-postgres-db"
+            - "indexer-graphql-api"
         restart: always
         env_file:
             - .env
         networks:
-            - indexer-service
+            - indexer
+            - datalayer
 volumes:
     db_data:
     ganache-data:
 networks:
-    indexer-service:
+    indexer:
         name: indexer_test_network
     datalayer:
         name: datalayer_test_network


### PR DESCRIPTION
# 🤖 Linear

Closes GIT-76 GIT-77

## Description

- add a new Hasura service to docker-compose for serving the GraphQL of the data layer

Note: this Hasura is a different service from the one that gets exposed for Envio