### PR TITLE
fix: save strategy address on Pool Created

### DIFF
--- a/packages/data-flow/src/orchestrator.ts
+++ b/packages/data-flow/src/orchestrator.ts
@@ -117,7 +117,7 @@ export class Orchestrator {
                     const handleable = existsHandler(event.strategyId);
                     await this.strategyRegistry.saveStrategyId(
                         this.chainId,
-                        event.srcAddress,
+                        event.params.strategy,
                         event.strategyId,
                         handleable,
                     );

--- a/packages/data-flow/test/unit/orchestrator.spec.ts
+++ b/packages/data-flow/test/unit/orchestrator.spec.ts
@@ -281,7 +281,7 @@ describe("Orchestrator", { sequential: true }, () => {
         });
 
         it("save strategyId to registry on PoolCreated event", async () => {
-            const strategyAddress = "0x123" as Address;
+            const strategyAddress = "0xff212432" as Address;
             const strategyId = "0xunknown" as Hex;
             const existingStrategyId =
                 "0x6f9291df02b2664139cec5703c124e4ebce32879c74b6297faa1468aa5ff9ebf" as Hex;
@@ -314,14 +314,14 @@ describe("Orchestrator", { sequential: true }, () => {
             expect(mockStrategyRegistry.saveStrategyId).toHaveBeenNthCalledWith(
                 1,
                 chainId,
-                strategyAddress,
+                mockEvent.params.strategy,
                 strategyId,
                 false,
             );
             expect(mockStrategyRegistry.saveStrategyId).toHaveBeenNthCalledWith(
                 2,
                 chainId,
-                strategyAddress,
+                mockEvent.params.strategy,
                 existingStrategyId,
                 true,
             );


### PR DESCRIPTION
## Description

Fixes Orchestrator code, where we have to save the strategy contract address, not the srcAddress of the event (which is Allo contract)

## Checklist before requesting a review

-   [x] I have conducted a self-review of my code.
-   [x] I have conducted a QA.
-   [x] If it is a core feature, I have included comprehensive tests.
