### PR TITLE
fix: incorrect timestamps

### DIFF
--- a/packages/data-flow/src/orchestrator.ts
+++ b/packages/data-flow/src/orchestrator.ts
@@ -25,6 +25,7 @@ import {
     RetryStrategy,
     StrategyEvent,
     stringify,
+    TimestampMs,
     Token,
 } from "@grants-stack-indexer/shared";
 
@@ -36,7 +37,7 @@ import { CoreDependencies, DataLoader, delay, IQueue, iStrategyAbi, Queue } from
 
 type TokenWithTimestamps = {
     token: Token;
-    timestamps: number[];
+    timestamps: TimestampMs[];
 };
 
 /**

--- a/packages/data-flow/test/unit/eventsFetcher.spec.ts
+++ b/packages/data-flow/test/unit/eventsFetcher.spec.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, Mocked, vi } from "vitest";
 
 import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
-import { AnyIndexerFetchedEvent, ChainId, PoolCreatedParams } from "@grants-stack-indexer/shared";
+import {
+    AnyIndexerFetchedEvent,
+    ChainId,
+    PoolCreatedParams,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
 
 import { EventsFetcher } from "../../src/eventsFetcher.js";
 
@@ -23,7 +28,7 @@ describe("EventsFetcher", () => {
             {
                 chainId: 1,
                 blockNumber: 12345,
-                blockTimestamp: 123123123,
+                blockTimestamp: 123123123000 as TimestampMs,
                 contractName: "Allo",
                 eventName: "PoolCreated",
                 srcAddress: "0x1234567890123456789012345678901234567890",
@@ -38,7 +43,7 @@ describe("EventsFetcher", () => {
             {
                 chainId: 1,
                 blockNumber: 12345,
-                blockTimestamp: 123123123,
+                blockTimestamp: 123123123000 as TimestampMs,
                 contractName: "Allo",
                 eventName: "PoolCreated",
                 srcAddress: "0x1234567890123456789012345678901234567890",

--- a/packages/data-flow/test/unit/eventsProcessor.spec.ts
+++ b/packages/data-flow/test/unit/eventsProcessor.spec.ts
@@ -7,7 +7,13 @@ import {
     StrategyProcessor,
 } from "@grants-stack-indexer/processors";
 import { Changeset } from "@grants-stack-indexer/repository";
-import { AnyEvent, ChainId, ContractName, ProcessorEvent } from "@grants-stack-indexer/shared";
+import {
+    AnyEvent,
+    ChainId,
+    ContractName,
+    ProcessorEvent,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
 
 import { EventsProcessor } from "../../src/eventsProcessor.js";
 import { InvalidEvent } from "../../src/exceptions/index.js";
@@ -97,7 +103,7 @@ describe("EventsProcessor", () => {
             contractName: "Unknown" as unknown as ContractName,
             eventName: "PoolCreated",
             blockNumber: 1,
-            blockTimestamp: 1,
+            blockTimestamp: 1704067241331 as TimestampMs,
             chainId,
             logIndex: 1,
             srcAddress: "0x0",

--- a/packages/data-flow/test/unit/orchestrator.spec.ts
+++ b/packages/data-flow/test/unit/orchestrator.spec.ts
@@ -30,6 +30,7 @@ import {
     ProcessorEvent,
     RateLimitError,
     StrategyEvent,
+    TimestampMs,
     Token,
     TokenCode,
 } from "@grants-stack-indexer/shared";
@@ -881,7 +882,7 @@ describe("Orchestrator", { sequential: true }, () => {
             ] as unknown as AnyIndexerFetchedEvent[];
 
             vi.spyOn(mockPricingProvider, "getTokenPrices").mockResolvedValue([
-                { timestampMs: 1000, priceUsd: 1500 },
+                { timestampMs: 1000 as TimestampMs, priceUsd: 1500 },
             ]);
 
             vi.spyOn(mockMetadataProvider, "getMetadata").mockResolvedValue({ name: "Test" });

--- a/packages/data-flow/test/unit/retroactiveProcessor.spec.ts
+++ b/packages/data-flow/test/unit/retroactiveProcessor.spec.ts
@@ -23,6 +23,7 @@ import {
     mergeDeep,
     ProcessorEvent,
     RateLimitError,
+    TimestampMs,
 } from "@grants-stack-indexer/shared";
 
 import {
@@ -564,7 +565,7 @@ export const createMockEvent = <T extends ContractToEventName<"Strategy">>(
         params,
         srcAddress: "0x1234567890123456789012345678901234567890",
         blockNumber: 118034410,
-        blockTimestamp: 1000000000,
+        blockTimestamp: 1704067241331 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Strategy",
         logIndex: 1,

--- a/packages/indexer-client/src/providers/envioIndexerClient.ts
+++ b/packages/indexer-client/src/providers/envioIndexerClient.ts
@@ -1,6 +1,11 @@
 import { gql, GraphQLClient } from "graphql-request";
 
-import { AnyIndexerFetchedEvent, ChainId, stringify } from "@grants-stack-indexer/shared";
+import {
+    AnyIndexerFetchedEvent,
+    ChainId,
+    stringify,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
 
 import { IndexerClientError, InvalidIndexerResponse } from "../exceptions/index.js";
 import {
@@ -69,6 +74,11 @@ export class EnvioIndexerClient implements IIndexerClient {
             const events = response?.raw_events;
 
             if (events) {
+                // Convert timestamps from seconds to milliseconds
+                events.forEach((event) => {
+                    event.blockTimestamp = (event.blockTimestamp * 1000) as TimestampMs;
+                });
+
                 if (allowPartialLastBlock || events.length === 0) {
                     return events;
                 } else {
@@ -233,6 +243,10 @@ export class EnvioIndexerClient implements IIndexerClient {
             )) as { raw_events: AnyIndexerFetchedEvent[] };
 
             if (response?.raw_events) {
+                // Convert timestamps from seconds to milliseconds
+                response.raw_events.forEach((event) => {
+                    event.blockTimestamp = (event.blockTimestamp * 1000) as TimestampMs;
+                });
                 return response.raw_events;
             } else {
                 throw new InvalidIndexerResponse(stringify(response));

--- a/packages/indexer-client/test/unit/envioIndexerClient.spec.ts
+++ b/packages/indexer-client/test/unit/envioIndexerClient.spec.ts
@@ -23,75 +23,79 @@ vi.mock("graphql-request", async (importOriginal) => {
     };
 });
 
+type EnvioEvent = Omit<AnyIndexerFetchedEvent, "blockTimestamp"> & {
+    blockTimestamp: number;
+};
+
 describe("EnvioIndexerClient", () => {
     let envioIndexerClient: EnvioIndexerClient;
     let graphqlClient: Mocked<GraphQLClient>;
-
-    // Sample test data
-    const testEvents: AnyIndexerFetchedEvent[] = [
-        {
-            chainId: 1,
-            blockNumber: 100,
-            blockTimestamp: 123123123,
-            contractName: "Allo",
-            eventName: "PoolCreated",
-            srcAddress: "0x1234",
-            logIndex: 1,
-            params: {
-                contractAddress: "0x1234",
-                tokenAddress: "0x1234",
-                amount: 1000n,
-            } as unknown as PoolCreatedParams,
-            transactionFields: { hash: "0x123", transactionIndex: 1 },
-        },
-        {
-            chainId: 1,
-            blockNumber: 100,
-            blockTimestamp: 123123123,
-            contractName: "Allo",
-            eventName: "PoolCreated",
-            srcAddress: "0x1234",
-            logIndex: 3,
-            params: {
-                contractAddress: "0x1234",
-                tokenAddress: "0x1234",
-                amount: 1000n,
-            } as unknown as PoolCreatedParams,
-            transactionFields: { hash: "0x123", transactionIndex: 1 },
-        },
-        {
-            chainId: 1,
-            blockNumber: 101,
-            blockTimestamp: 123123124,
-            contractName: "Allo",
-            eventName: "PoolCreated",
-            srcAddress: "0x3456",
-            logIndex: 1,
-            params: {
-                contractAddress: "0x1234",
-                tokenAddress: "0x1234",
-                amount: 1000n,
-            } as unknown as PoolCreatedParams,
-            transactionFields: { hash: "0x123", transactionIndex: 1 },
-        },
-        {
-            chainId: 10,
-            blockNumber: 1200,
-            blockTimestamp: 123123123,
-            contractName: "Allo",
-            eventName: "PoolCreated",
-            srcAddress: "0x1234",
-            logIndex: 1,
-            params: {
-                contractAddress: "0x1234",
-                tokenAddress: "0x1234",
-                amount: 1000n,
-            } as unknown as PoolCreatedParams,
-            transactionFields: { hash: "0x123", transactionIndex: 1 },
-        },
-    ];
+    let testEvents: EnvioEvent[];
 
     beforeEach(() => {
+        // Sample test data
+        testEvents = [
+            {
+                chainId: 1,
+                blockNumber: 100,
+                blockTimestamp: 123123123,
+                contractName: "Allo",
+                eventName: "PoolCreated",
+                srcAddress: "0x1234",
+                logIndex: 1,
+                params: {
+                    contractAddress: "0x1234",
+                    tokenAddress: "0x1234",
+                    amount: 1000n,
+                } as unknown as PoolCreatedParams,
+                transactionFields: { hash: "0x123", transactionIndex: 1 },
+            },
+            {
+                chainId: 1,
+                blockNumber: 100,
+                blockTimestamp: 123123123,
+                contractName: "Allo",
+                eventName: "PoolCreated",
+                srcAddress: "0x1234",
+                logIndex: 3,
+                params: {
+                    contractAddress: "0x1234",
+                    tokenAddress: "0x1234",
+                    amount: 1000n,
+                } as unknown as PoolCreatedParams,
+                transactionFields: { hash: "0x123", transactionIndex: 1 },
+            },
+            {
+                chainId: 1,
+                blockNumber: 101,
+                blockTimestamp: 123123124,
+                contractName: "Allo",
+                eventName: "PoolCreated",
+                srcAddress: "0x3456",
+                logIndex: 1,
+                params: {
+                    contractAddress: "0x1234",
+                    tokenAddress: "0x1234",
+                    amount: 1000n,
+                } as unknown as PoolCreatedParams,
+                transactionFields: { hash: "0x123", transactionIndex: 1 },
+            },
+            {
+                chainId: 10,
+                blockNumber: 1200,
+                blockTimestamp: 123123123,
+                contractName: "Allo",
+                eventName: "PoolCreated",
+                srcAddress: "0x1234",
+                logIndex: 1,
+                params: {
+                    contractAddress: "0x1234",
+                    tokenAddress: "0x1234",
+                    amount: 1000n,
+                } as unknown as PoolCreatedParams,
+                transactionFields: { hash: "0x123", transactionIndex: 1 },
+            },
+        ];
         envioIndexerClient = new EnvioIndexerClient("http://example.com/graphql", "secret");
         graphqlClient = envioIndexerClient["client"] as unknown as Mocked<GraphQLClient>;
     });
@@ -129,7 +133,7 @@ describe("EnvioIndexerClient", () => {
                     };
                     const { chainId, blockNumber, logIndex, limit } = variables;
 
-                    const filteredEvents = testEvents
+                    const filteredEvents = structuredClone(testEvents)
                         .filter((event) => {
                             // Match chainId
                             if (event.chainId !== chainId) return false;
@@ -290,7 +294,7 @@ describe("EnvioIndexerClient", () => {
                         };
                         const { chainId, blockNumber, logIndex, limit } = variables;
 
-                        const filteredEvents = testEvents
+                        const filteredEvents = structuredClone(testEvents)
                             .filter((event) => {
                                 // Match chainId
                                 if (event.chainId !== chainId) return false;
@@ -322,12 +326,29 @@ describe("EnvioIndexerClient", () => {
             });
 
             expect(result).toHaveLength(2);
-            expect(result).toEqual(testEvents.slice(0, 2));
+            expect(result).toEqual(
+                testEvents
+                    .slice(0, 2)
+                    .map((event) => ({ ...event, blockTimestamp: event.blockTimestamp * 1000 })),
+            );
             expect(graphqlClient.request).toHaveBeenCalledTimes(2);
             expect(graphqlClient.request).toHaveBeenNthCalledWith(2, expect.any(String), {
                 chainId: 1,
                 blockNumber: 101,
             });
+        });
+
+        it("returns events with blockTimestamp in milliseconds", async () => {
+            const result = await envioIndexerClient.getEventsAfterBlockNumberAndLogIndex({
+                chainId: 1 as ChainId,
+                blockNumber: 100,
+                logIndex: 0,
+                limit: 100,
+            });
+            expect(result).toHaveLength(3);
+            expect(result[0]!.blockTimestamp).toBe(123123123000);
+            expect(result[1]!.blockTimestamp).toBe(123123123000);
+            expect(result[2]!.blockTimestamp).toBe(123123124000);
         });
     });
 
@@ -354,7 +375,7 @@ describe("EnvioIndexerClient", () => {
                     const { chainId, limit = 100, srcAddresses } = filters;
                     const { fromBlock, fromLogIndex, toBlock, toLogIndex } = filters;
 
-                    const filteredEvents = testEvents
+                    const filteredEvents = structuredClone(testEvents)
                         .filter((event) => {
                             if (event.chainId !== chainId) return false;
 
@@ -528,6 +549,18 @@ describe("EnvioIndexerClient", () => {
                     limit: 100, // Ensure the default limit is used
                 },
             );
+        });
+
+        it("returns events with blockTimestamp in milliseconds", async () => {
+            const result = await envioIndexerClient.getEvents({
+                chainId: 1 as ChainId,
+                from: { blockNumber: 100, logIndex: 0 },
+                limit: 100,
+            });
+            expect(result).toHaveLength(3);
+            expect(result[0]!.blockTimestamp).toBe(123123123000);
+            expect(result[1]!.blockTimestamp).toBe(123123123000);
+            expect(result[2]!.blockTimestamp).toBe(123123124000);
         });
     });
 

--- a/packages/pricing/README.md
+++ b/packages/pricing/README.md
@@ -83,7 +83,7 @@ const price = await coingecko.getTokenPrice(
 
 Available methods
 
--   `getTokenPrice(chainId: number, tokenAddress: Address, startTimestampMs: number, endTimestampMs: number): Promise<TokenPrice | undefined>`
+-   `getTokenPrice(chainId: number, tokenAddress: Address, startTimestampMs: TimestampMs, endTimestampMs: TimestampMs): Promise<TokenPrice | undefined>`
 
 ## References
 

--- a/packages/pricing/src/interfaces/pricing.interface.ts
+++ b/packages/pricing/src/interfaces/pricing.interface.ts
@@ -1,4 +1,4 @@
-import { TokenCode } from "@grants-stack-indexer/shared";
+import { TimestampMs, TokenCode } from "@grants-stack-indexer/shared";
 
 import { TokenPrice } from "../internal.js";
 
@@ -22,8 +22,8 @@ export interface IPricingProvider {
      */
     getTokenPrice(
         tokenCode: TokenCode,
-        startTimestampMs: number,
-        endTimestampMs?: number,
+        startTimestampMs: TimestampMs,
+        endTimestampMs?: TimestampMs,
     ): Promise<TokenPrice | undefined>;
 
     /**
@@ -33,5 +33,5 @@ export interface IPricingProvider {
      * @returns A promise that resolves to the prices of the token for each requested timestamp.
      * The returned prices may not have the exact timestamps requested. Depends on the implementation.
      */
-    getTokenPrices(tokenCode: TokenCode, timestamps: number[]): Promise<TokenPrice[]>;
+    getTokenPrices(tokenCode: TokenCode, timestamps: TimestampMs[]): Promise<TokenPrice[]>;
 }

--- a/packages/pricing/src/providers/cachingProxy.provider.ts
+++ b/packages/pricing/src/providers/cachingProxy.provider.ts
@@ -1,10 +1,10 @@
 import { ICache, PriceCacheKey } from "@grants-stack-indexer/repository";
-import { ICacheable, ILogger, TokenCode } from "@grants-stack-indexer/shared";
+import { ICacheable, ILogger, TimestampMs, TokenCode } from "@grants-stack-indexer/shared";
 
 import { IPricingProvider, TokenPrice } from "../internal.js";
 
 type CacheResult = {
-    timestampMs: number;
+    timestampMs: TimestampMs;
     price: TokenPrice | undefined;
 };
 
@@ -24,8 +24,8 @@ export class CachingPricingProvider implements IPricingProvider, ICacheable {
     /** @inheritdoc */
     async getTokenPrice(
         tokenCode: TokenCode,
-        startTimestampMs: number,
-        endTimestampMs?: number,
+        startTimestampMs: TimestampMs,
+        endTimestampMs?: TimestampMs,
     ): Promise<TokenPrice | undefined> {
         let cachedPrice: TokenPrice | undefined = undefined;
         try {
@@ -87,7 +87,7 @@ export class CachingPricingProvider implements IPricingProvider, ICacheable {
      * Note: it caches the closest prices to the requested timestamps.
      * Uses binary search to find the closest price for each requested timestamp.
      */
-    async getTokenPrices(tokenCode: TokenCode, timestamps: number[]): Promise<TokenPrice[]> {
+    async getTokenPrices(tokenCode: TokenCode, timestamps: TimestampMs[]): Promise<TokenPrice[]> {
         if (timestamps.length === 0) return [];
 
         const cachedPrices = await this.getCachedPrices(tokenCode, timestamps);
@@ -129,7 +129,7 @@ export class CachingPricingProvider implements IPricingProvider, ICacheable {
      */
     private async getCachedPrices(
         tokenCode: TokenCode,
-        timestamps: number[],
+        timestamps: TimestampMs[],
     ): Promise<PromiseSettledResult<CacheResult>[]> {
         return Promise.allSettled(
             timestamps.map(async (timestampMs) => {
@@ -156,9 +156,9 @@ export class CachingPricingProvider implements IPricingProvider, ICacheable {
      * @returns The timestamps that need to be fetched
      */
     private getTimestampsToFetch(
-        timestamps: number[],
+        timestamps: TimestampMs[],
         cachedPrices: PromiseSettledResult<CacheResult>[],
-    ): number[] {
+    ): TimestampMs[] {
         return timestamps.filter((_, index) => {
             const result = cachedPrices[index];
             if (!result || result.status === "rejected") return true;
@@ -175,7 +175,7 @@ export class CachingPricingProvider implements IPricingProvider, ICacheable {
      */
     private getClosestPricesWithCache(
         tokenCode: TokenCode,
-        timestampsToFetch: number[],
+        timestampsToFetch: TimestampMs[],
         sortedFetchedPrices: TokenPrice[],
     ): TokenPrice[] {
         return timestampsToFetch

--- a/packages/pricing/src/providers/coingecko.provider.ts
+++ b/packages/pricing/src/providers/coingecko.provider.ts
@@ -6,6 +6,7 @@ import {
     NonRetriableError,
     RateLimitError,
     stringify,
+    TimestampMs,
     TokenCode,
 } from "@grants-stack-indexer/shared";
 
@@ -92,8 +93,8 @@ export class CoingeckoProvider implements IPricingProvider {
     /* @inheritdoc */
     async getTokenPrice(
         tokenCode: TokenCode,
-        startTimestampMs: number,
-        endTimestampMs?: number,
+        startTimestampMs: TimestampMs,
+        endTimestampMs?: TimestampMs,
     ): Promise<TokenPrice | undefined> {
         const tokenId = TokenMapping[tokenCode];
         if (!tokenId) {
@@ -104,7 +105,7 @@ export class CoingeckoProvider implements IPricingProvider {
         }
 
         if (!endTimestampMs) {
-            endTimestampMs = startTimestampMs + TIME_DELTA;
+            endTimestampMs = (startTimestampMs + TIME_DELTA) as TimestampMs;
         }
 
         if (startTimestampMs > endTimestampMs) {
@@ -122,7 +123,7 @@ export class CoingeckoProvider implements IPricingProvider {
             }
 
             return {
-                timestampMs: closestEntry[0],
+                timestampMs: closestEntry[0] as TimestampMs,
                 priceUsd: closestEntry[1],
             };
         } catch (error: unknown) {

--- a/packages/pricing/src/providers/dummy.provider.ts
+++ b/packages/pricing/src/providers/dummy.provider.ts
@@ -1,4 +1,4 @@
-import { TokenCode } from "@grants-stack-indexer/shared";
+import { TimestampMs, TokenCode } from "@grants-stack-indexer/shared";
 
 import { IPricingProvider, TokenPrice } from "../internal.js";
 
@@ -13,8 +13,8 @@ export class DummyPricingProvider implements IPricingProvider {
     /* @inheritdoc */
     async getTokenPrice(
         _tokenCode: TokenCode,
-        startTimestampMs: number,
-        _endTimestampMs?: number,
+        startTimestampMs: TimestampMs,
+        _endTimestampMs?: TimestampMs,
     ): Promise<TokenPrice | undefined> {
         return Promise.resolve({
             priceUsd: this.dummyPrice,
@@ -23,7 +23,7 @@ export class DummyPricingProvider implements IPricingProvider {
     }
 
     /* @inheritdoc */
-    async getTokenPrices(_tokenCode: TokenCode, timestamps: number[]): Promise<TokenPrice[]> {
+    async getTokenPrices(_tokenCode: TokenCode, timestamps: TimestampMs[]): Promise<TokenPrice[]> {
         return timestamps.map((timestampMs) => ({
             priceUsd: this.dummyPrice,
             timestampMs,

--- a/packages/pricing/src/types/coingecko.types.ts
+++ b/packages/pricing/src/types/coingecko.types.ts
@@ -1,4 +1,4 @@
-import { Branded } from "@grants-stack-indexer/shared";
+import { Branded, TimestampMs } from "@grants-stack-indexer/shared";
 
 export type CoingeckoSupportedChainId =
     | 1
@@ -17,7 +17,7 @@ export type CoingeckoTokenId = Branded<string, "CoingeckoTokenId">;
 export type CoingeckoPlatformId = Branded<string, "CoingeckoPlatformId">;
 
 export type CoingeckoPriceChartData = {
-    prices: [number, number][];
-    market_caps: [number, number][];
-    total_volumes: [number, number][];
+    prices: [TimestampMs, number][];
+    market_caps: [TimestampMs, number][];
+    total_volumes: [TimestampMs, number][];
 };

--- a/packages/pricing/src/types/pricing.types.ts
+++ b/packages/pricing/src/types/pricing.types.ts
@@ -1,8 +1,10 @@
+import { TimestampMs } from "@grants-stack-indexer/shared";
+
 /**
  * @timestampMs - The timestamp in milliseconds
  * @priceUsd - The price in USD
  */
 export type TokenPrice = {
-    timestampMs: number;
+    timestampMs: TimestampMs;
     priceUsd: number;
 };

--- a/packages/pricing/test/providers/cachingProxy.provider.spec.ts
+++ b/packages/pricing/test/providers/cachingProxy.provider.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ICache, PriceCacheKey } from "@grants-stack-indexer/repository";
-import { ICacheable, ILogger, TokenCode } from "@grants-stack-indexer/shared";
+import { ICacheable, ILogger, TimestampMs, TokenCode } from "@grants-stack-indexer/shared";
 
 import { IPricingProvider, TokenPrice } from "../../src/internal.js";
 import { CachingPricingProvider } from "../../src/providers/cachingProxy.provider.js";
@@ -37,8 +37,8 @@ describe("CachingPricingProvider", () => {
             address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             decimals: 6,
         };
-        const testStartTime = 1234567890000;
-        const testEndTime = 1234567899999;
+        const testStartTime = 1234567890000 as TimestampMs;
+        const testEndTime = 1234567899999 as TimestampMs;
         const testPrice: TokenPrice = {
             priceUsd: 0.99,
             timestampMs: testStartTime,

--- a/packages/pricing/test/providers/coingecko.provider.spec.ts
+++ b/packages/pricing/test/providers/coingecko.provider.spec.ts
@@ -5,6 +5,7 @@ import {
     NetworkError,
     NonRetriableError,
     RateLimitError,
+    TimestampMs,
     TokenCode,
 } from "@grants-stack-indexer/shared";
 
@@ -64,12 +65,12 @@ describe("CoingeckoProvider", () => {
 
             const result = await provider.getTokenPrice(
                 "ETH" as TokenCode,
-                1609459200000,
-                1609545600000,
+                1609459200000 as TimestampMs,
+                1609545600000 as TimestampMs,
             );
 
             const expectedPrice: TokenPrice = {
-                timestampMs: 1609459200000,
+                timestampMs: 1609459200000 as TimestampMs,
                 priceUsd: 100,
             };
 
@@ -85,10 +86,13 @@ describe("CoingeckoProvider", () => {
             };
             mock.get.mockResolvedValueOnce({ status: 200, data: mockResponse });
 
-            const result = await provider.getTokenPrice("ETH" as TokenCode, 1609459200000);
+            const result = await provider.getTokenPrice(
+                "ETH" as TokenCode,
+                1609459200000 as TimestampMs,
+            );
 
             const expectedPrice: TokenPrice = {
-                timestampMs: 1609459200000,
+                timestampMs: 1609459200000 as TimestampMs,
                 priceUsd: 100,
             };
 
@@ -106,8 +110,8 @@ describe("CoingeckoProvider", () => {
 
             const result = await provider.getTokenPrice(
                 "ETH" as TokenCode,
-                1609459200000,
-                1609545600000,
+                1609459200000 as TimestampMs,
+                1609545600000 as TimestampMs,
             );
 
             expect(result).toBeUndefined();
@@ -116,8 +120,8 @@ describe("CoingeckoProvider", () => {
         it("return undefined when endTimestamp is greater than startTimestamp", async () => {
             const result = await provider.getTokenPrice(
                 "ETH" as TokenCode,
-                1609545600000, // startTimestamp
-                1609459200000, // endTimestamp
+                1609545600000 as TimestampMs, // startTimestamp
+                1609459200000 as TimestampMs, // endTimestamp
             );
 
             expect(result).toBeUndefined();
@@ -134,7 +138,11 @@ describe("CoingeckoProvider", () => {
             });
 
             await expect(
-                provider.getTokenPrice("ETH" as TokenCode, 1609459200000, 1609545600000),
+                provider.getTokenPrice(
+                    "ETH" as TokenCode,
+                    1609459200000 as TimestampMs,
+                    1609545600000 as TimestampMs,
+                ),
             ).rejects.toThrow(RateLimitError);
         });
 
@@ -146,13 +154,21 @@ describe("CoingeckoProvider", () => {
             });
 
             await expect(
-                provider.getTokenPrice("ETH" as TokenCode, 1609459200000, 1609545600000),
+                provider.getTokenPrice(
+                    "ETH" as TokenCode,
+                    1609459200000 as TimestampMs,
+                    1609545600000 as TimestampMs,
+                ),
             ).rejects.toThrow(NonRetriableError);
         });
 
         it("throw UnsupportedTokenException for unsupported token", async () => {
             await expect(() =>
-                provider.getTokenPrice("UNSUPPORTED" as TokenCode, 1609459200000, 1609545600000),
+                provider.getTokenPrice(
+                    "UNSUPPORTED" as TokenCode,
+                    1609459200000 as TimestampMs,
+                    1609545600000 as TimestampMs,
+                ),
             ).rejects.toThrow(UnsupportedToken);
         });
 
@@ -163,7 +179,11 @@ describe("CoingeckoProvider", () => {
                 isAxiosError: true,
             });
             await expect(
-                provider.getTokenPrice("ETH" as TokenCode, 1609459200000, 1609545600000),
+                provider.getTokenPrice(
+                    "ETH" as TokenCode,
+                    1609459200000 as TimestampMs,
+                    1609545600000 as TimestampMs,
+                ),
             ).rejects.toThrow(NetworkError);
         });
 
@@ -175,7 +195,11 @@ describe("CoingeckoProvider", () => {
             });
 
             await expect(
-                provider.getTokenPrice("ETH" as TokenCode, 1609459200000, 1609545600000),
+                provider.getTokenPrice(
+                    "ETH" as TokenCode,
+                    1609459200000 as TimestampMs,
+                    1609545600000 as TimestampMs,
+                ),
             ).rejects.toThrow(NetworkError);
         });
     });

--- a/packages/pricing/test/providers/dummy.provider.spec.ts
+++ b/packages/pricing/test/providers/dummy.provider.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { TokenCode } from "@grants-stack-indexer/shared";
+import { TimestampMs, TokenCode } from "@grants-stack-indexer/shared";
 
 import { DummyPricingProvider } from "../../src/providers/dummy.provider.js";
 
@@ -8,7 +8,7 @@ describe("DummyPricingProvider", () => {
     it("return 1 for all token prices", async () => {
         const provider = new DummyPricingProvider();
 
-        const response = await provider.getTokenPrice("ETH" as TokenCode, 11111111);
+        const response = await provider.getTokenPrice("ETH" as TokenCode, 11111111 as TimestampMs);
 
         expect(response).toEqual({
             priceUsd: 1,
@@ -19,7 +19,7 @@ describe("DummyPricingProvider", () => {
     describe("getTokenPrices", () => {
         it("returns dummy prices for all timestamps", async () => {
             const provider = new DummyPricingProvider(1);
-            const timestamps = [1000, 2000, 3000];
+            const timestamps = [1000, 2000, 3000] as TimestampMs[];
 
             const result = await provider.getTokenPrices("ETH" as TokenCode, timestamps);
             expect(result).toEqual(

--- a/packages/pricing/test/providers/dummy.provider.spec.ts
+++ b/packages/pricing/test/providers/dummy.provider.spec.ts
@@ -8,18 +8,21 @@ describe("DummyPricingProvider", () => {
     it("return 1 for all token prices", async () => {
         const provider = new DummyPricingProvider();
 
-        const response = await provider.getTokenPrice("ETH" as TokenCode, 11111111 as TimestampMs);
+        const response = await provider.getTokenPrice(
+            "ETH" as TokenCode,
+            1111111100000 as TimestampMs,
+        );
 
         expect(response).toEqual({
             priceUsd: 1,
-            timestampMs: 11111111,
+            timestampMs: 1111111100000,
         });
     });
 
     describe("getTokenPrices", () => {
         it("returns dummy prices for all timestamps", async () => {
             const provider = new DummyPricingProvider(1);
-            const timestamps = [1000, 2000, 3000] as TimestampMs[];
+            const timestamps = [1111111100000, 1111111200000, 1111111300000] as TimestampMs[];
 
             const result = await provider.getTokenPrices("ETH" as TokenCode, timestamps);
             expect(result).toEqual(

--- a/packages/processors/src/helpers/pricing.ts
+++ b/packages/processors/src/helpers/pricing.ts
@@ -1,5 +1,5 @@
 import { IPricingProvider } from "@grants-stack-indexer/pricing";
-import { Token } from "@grants-stack-indexer/shared";
+import { TimestampMs, Token } from "@grants-stack-indexer/shared";
 
 import { TokenPriceNotFoundError } from "../internal.js";
 import { calculateAmountInToken, calculateAmountInUsd } from "./index.js";
@@ -17,9 +17,9 @@ export const getTokenAmountInUsd = async (
     pricingProvider: IPricingProvider,
     token: Token,
     amount: bigint,
-    timestamp: number,
-    timestampEnd?: number,
-): Promise<{ amountInUsd: string; timestamp: number }> => {
+    timestamp: TimestampMs,
+    timestampEnd?: TimestampMs,
+): Promise<{ amountInUsd: string; timestamp: TimestampMs }> => {
     const tokenPrice = await pricingProvider.getTokenPrice(
         token.priceSourceCode,
         timestamp,
@@ -49,8 +49,8 @@ export const getUsdInTokenAmount = async (
     pricingProvider: IPricingProvider,
     token: Token,
     amountInUSD: string,
-    timestamp: number,
-    timestampEnd?: number,
+    timestamp: TimestampMs,
+    timestampEnd?: TimestampMs,
 ): Promise<{ amount: bigint; price: number; timestamp: Date }> => {
     const closestPrice = await pricingProvider.getTokenPrice(
         token.priceSourceCode,

--- a/packages/processors/src/interfaces/strategyHandler.interface.ts
+++ b/packages/processors/src/interfaces/strategyHandler.interface.ts
@@ -3,6 +3,7 @@ import type {
     Address,
     ContractToEventName,
     ProcessorEvent,
+    TimestampMs,
     Token,
 } from "@grants-stack-indexer/shared";
 
@@ -42,7 +43,7 @@ export interface IStrategyHandler<E extends ContractToEventName<"Strategy">> {
     fetchMatchAmount(
         matchingFundsAvailable: number,
         token: Token,
-        blockTimestamp: number,
+        blockTimestamp: TimestampMs,
     ): Promise<{
         matchAmount: bigint;
         matchAmountInUsd: string;

--- a/packages/processors/src/processors/allo/handlers/poolCreated.handler.ts
+++ b/packages/processors/src/processors/allo/handlers/poolCreated.handler.ts
@@ -1,7 +1,7 @@
 import { getAddress, zeroAddress } from "viem";
 
 import type { Changeset, NewRound, PendingRoundRole } from "@grants-stack-indexer/repository";
-import type { ChainId, ProcessorEvent, Token } from "@grants-stack-indexer/shared";
+import type { ChainId, ProcessorEvent, TimestampMs, Token } from "@grants-stack-indexer/shared";
 import { getToken, isAlloNativeToken } from "@grants-stack-indexer/shared";
 
 import type { IEventHandler, ProcessorDependencies, StrategyTimings } from "../../../internal.js";
@@ -193,7 +193,7 @@ export class PoolCreatedHandler implements IEventHandler<"Allo", "PoolCreated"> 
     private async getTokenAmountInUsd(
         token: Token,
         amount: bigint,
-        timestamp: number,
+        timestamp: TimestampMs,
     ): Promise<string> {
         const { pricingProvider } = this.dependencies;
         const tokenPrice = await pricingProvider.getTokenPrice(token.priceSourceCode, timestamp);

--- a/packages/processors/src/processors/strategy/common/base.strategy.ts
+++ b/packages/processors/src/processors/strategy/common/base.strategy.ts
@@ -1,5 +1,11 @@
 import { Changeset } from "@grants-stack-indexer/repository";
-import { Address, ProcessorEvent, StrategyEvent, Token } from "@grants-stack-indexer/shared";
+import {
+    Address,
+    ProcessorEvent,
+    StrategyEvent,
+    TimestampMs,
+    Token,
+} from "@grants-stack-indexer/shared";
 
 import { IStrategyHandler, StrategyTimings } from "../../../internal.js";
 
@@ -31,7 +37,7 @@ export abstract class BaseStrategyHandler implements IStrategyHandler<StrategyEv
     async fetchMatchAmount(
         _matchingFundsAvailable: number,
         _token: Token,
-        _blockTimestamp: number,
+        _blockTimestamp: TimestampMs,
     ): Promise<{ matchAmount: bigint; matchAmountInUsd: string }> {
         return {
             matchAmount: 0n,

--- a/packages/processors/src/processors/strategy/donationVotingMerkleDistributionDirectTransfer/dvmdDirectTransfer.handler.ts
+++ b/packages/processors/src/processors/strategy/donationVotingMerkleDistributionDirectTransfer/dvmdDirectTransfer.handler.ts
@@ -6,6 +6,7 @@ import {
     ChainId,
     ProcessorEvent,
     StrategyEvent,
+    TimestampMs,
     Token,
 } from "@grants-stack-indexer/shared";
 
@@ -120,7 +121,7 @@ export class DVMDDirectTransferStrategyHandler extends BaseStrategyHandler {
     override async fetchMatchAmount(
         matchingFundsAvailable: number,
         token: Token,
-        blockTimestamp: number,
+        blockTimestamp: TimestampMs,
     ): Promise<{ matchAmount: bigint; matchAmountInUsd: string }> {
         const matchAmount = parseUnits(matchingFundsAvailable.toString(), token.decimals);
 
@@ -193,7 +194,7 @@ export class DVMDDirectTransferStrategyHandler extends BaseStrategyHandler {
     private async getTokenAmountInUsd(
         token: Token,
         amount: bigint,
-        timestamp: number,
+        timestamp: TimestampMs,
     ): Promise<string> {
         const { pricingProvider } = this.dependencies;
         const tokenPrice = await pricingProvider.getTokenPrice(token.priceSourceCode, timestamp);

--- a/packages/processors/test/allo/handlers/poolCreated.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolCreated.handler.spec.ts
@@ -85,7 +85,7 @@ describe("PoolCreatedHandler", () => {
 
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
             priceUsd: 100,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         });
         vi.spyOn(mockRoundRepository, "getPendingRoundRoles").mockResolvedValue([]);
 
@@ -158,7 +158,7 @@ describe("PoolCreatedHandler", () => {
 
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
             priceUsd: 100,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         });
         vi.spyOn(mockEvmProvider, "multicall").mockResolvedValue([
             1609459200n,
@@ -246,7 +246,7 @@ describe("PoolCreatedHandler", () => {
 
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
             priceUsd: 100,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         });
         vi.spyOn(mockRoundRepository, "getPendingRoundRoles").mockResolvedValue([]);
         vi.spyOn(mockEvmProvider, "getTransaction").mockResolvedValue({
@@ -337,7 +337,7 @@ describe("PoolCreatedHandler", () => {
         vi.spyOn(mockMetadataProvider, "getMetadata").mockResolvedValue(undefined);
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
             priceUsd: 100,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         });
         vi.spyOn(mockEvmProvider, "multicall").mockResolvedValue([
             1609459200n,
@@ -446,7 +446,7 @@ describe("PoolCreatedHandler", () => {
         });
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
             priceUsd: 2500,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         });
         vi.spyOn(mockEvmProvider, "multicall").mockResolvedValue([
             1609459200n,

--- a/packages/processors/test/allo/handlers/poolCreated.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolCreated.handler.spec.ts
@@ -5,7 +5,13 @@ import type { EvmProvider } from "@grants-stack-indexer/chain-providers";
 import type { IMetadataProvider } from "@grants-stack-indexer/metadata";
 import type { IPricingProvider } from "@grants-stack-indexer/pricing";
 import type { IRoundReadRepository, Round } from "@grants-stack-indexer/repository";
-import type { ChainId, DeepPartial, ProcessorEvent, TokenCode } from "@grants-stack-indexer/shared";
+import type {
+    ChainId,
+    DeepPartial,
+    ProcessorEvent,
+    TimestampMs,
+    TokenCode,
+} from "@grants-stack-indexer/shared";
 import { mergeDeep } from "@grants-stack-indexer/shared";
 
 import { PoolCreatedHandler } from "../../../src/processors/allo/handlers/poolCreated.handler.js";
@@ -16,7 +22,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "PoolCreated"> {
     const defaultEvent: ProcessorEvent<"Allo", "PoolCreated"> = {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911,
+        blockTimestamp: 1708369911 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "PoolCreated",

--- a/packages/processors/test/allo/handlers/poolFunded.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolFunded.handler.spec.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ChainId, ILogger, ProcessorEvent, Token } from "@grants-stack-indexer/shared";
+import type {
+    ChainId,
+    ILogger,
+    ProcessorEvent,
+    TimestampMs,
+    Token,
+} from "@grants-stack-indexer/shared";
 import { IPricingProvider } from "@grants-stack-indexer/pricing";
 import { IRoundReadRepository, Round } from "@grants-stack-indexer/repository";
 import { TOKENS, UnknownToken } from "@grants-stack-indexer/shared";
@@ -13,7 +19,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "PoolFunded"> {
     return {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911,
+        blockTimestamp: 1708369911 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "PoolFunded",

--- a/packages/processors/test/allo/handlers/poolFunded.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolFunded.handler.spec.ts
@@ -84,7 +84,7 @@ describe("PoolFundedHandler", () => {
         )[0];
         const mockPrice = {
             priceUsd: 2.5,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         };
         const round = {
             id: "1",

--- a/packages/processors/test/allo/handlers/poolFunded.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolFunded.handler.spec.ts
@@ -19,7 +19,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "PoolFunded"> {
     return {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911 as TimestampMs,
+        blockTimestamp: 1708369911000 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "PoolFunded",
@@ -84,7 +84,7 @@ describe("PoolFundedHandler", () => {
         )[0];
         const mockPrice = {
             priceUsd: 2.5,
-            timestampMs: 1708369911 as TimestampMs,
+            timestampMs: 1708369911000 as TimestampMs,
         };
         const round = {
             id: "1",

--- a/packages/processors/test/allo/handlers/poolMetadataUpdated.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolMetadataUpdated.handler.spec.ts
@@ -107,7 +107,7 @@ describe("PoolMetadataUpdatedHandler", () => {
         };
         const mockTokenPrice = {
             priceUsd: 2.5,
-            timestampMs: 1708369911,
+            timestampMs: 1708369911 as TimestampMs,
         };
         vi.spyOn(mockMetadataProvider, "getMetadata").mockResolvedValue(metadata);
         vi.spyOn(mockRoundRepository, "getRoundByIdOrThrow").mockResolvedValue(round as Round);

--- a/packages/processors/test/allo/handlers/poolMetadataUpdated.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/poolMetadataUpdated.handler.spec.ts
@@ -2,7 +2,13 @@ import { parseUnits } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IRoundReadRepository, Round } from "@grants-stack-indexer/repository";
-import type { ChainId, ILogger, ProcessorEvent, Token } from "@grants-stack-indexer/shared";
+import type {
+    ChainId,
+    ILogger,
+    ProcessorEvent,
+    TimestampMs,
+    Token,
+} from "@grants-stack-indexer/shared";
 import { IMetadataProvider } from "@grants-stack-indexer/metadata";
 import { IPricingProvider } from "@grants-stack-indexer/pricing";
 import { TOKENS } from "@grants-stack-indexer/shared";
@@ -16,7 +22,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "PoolMetadataUpdated"> {
     return {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911,
+        blockTimestamp: 1708369911 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "PoolMetadataUpdated",

--- a/packages/processors/test/allo/handlers/roleGranted.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/roleGranted.handler.spec.ts
@@ -1,7 +1,12 @@
 import { getAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+import type {
+    Bytes32String,
+    ChainId,
+    ProcessorEvent,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
 import { IRoundReadRepository, Round } from "@grants-stack-indexer/repository";
 
 import { RoleGrantedHandler } from "../../../src/processors/allo/handlers/index.js";
@@ -11,7 +16,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "RoleGranted"> {
     return {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911,
+        blockTimestamp: 1708369911 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "RoleGranted",

--- a/packages/processors/test/allo/handlers/roleGranted.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/roleGranted.handler.spec.ts
@@ -16,7 +16,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "RoleGranted"> {
     return {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911 as TimestampMs,
+        blockTimestamp: 1708369911000 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "RoleGranted",

--- a/packages/processors/test/allo/handlers/roleRevoked.handler.spec.ts
+++ b/packages/processors/test/allo/handlers/roleRevoked.handler.spec.ts
@@ -1,7 +1,13 @@
 import { getAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Bytes32String, ChainId, ILogger, ProcessorEvent } from "@grants-stack-indexer/shared";
+import type {
+    Bytes32String,
+    ChainId,
+    ILogger,
+    ProcessorEvent,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
 import { IRoundReadRepository, Round } from "@grants-stack-indexer/repository";
 
 import { RoleRevokedHandler } from "../../../src/processors/allo/handlers/roleRevoked.handler.js";
@@ -11,7 +17,7 @@ function createMockEvent(
 ): ProcessorEvent<"Allo", "RoleRevoked"> {
     return {
         blockNumber: 116385567,
-        blockTimestamp: 1708369911,
+        blockTimestamp: 1708369911 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Allo",
         eventName: "RoleRevoked",

--- a/packages/processors/test/mocks/event.mock.ts
+++ b/packages/processors/test/mocks/event.mock.ts
@@ -6,6 +6,7 @@ import {
     Hex,
     mergeDeep,
     ProcessorEvent,
+    TimestampMs,
 } from "@grants-stack-indexer/shared";
 
 /**
@@ -20,7 +21,7 @@ import {
  * @default
  *      srcAddress: "0x1234567890123456789012345678901234567890",
  *      blockNumber: 118034410,
- *      blockTimestamp: 1000000000,
+ *      blockTimestamp: 1704067241331 as TimestampMs,
  *      chainId: 10 as ChainId,
  *      contractName: "Strategy",
  *      logIndex: 1,
@@ -41,7 +42,7 @@ export const createMockEvent = <T extends ContractToEventName<"Strategy">>(
         params,
         srcAddress: "0x1234567890123456789012345678901234567890",
         blockNumber: 118034410,
-        blockTimestamp: 1000000000,
+        blockTimestamp: 1704067241331 as TimestampMs,
         chainId: 10 as ChainId,
         contractName: "Strategy",
         logIndex: 1,

--- a/packages/processors/test/registry/handlers/profileCreated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileCreated.handler.spec.ts
@@ -9,7 +9,13 @@ import {
     IProjectReadRepository,
     IRoundReadRepository,
 } from "@grants-stack-indexer/repository";
-import { Bytes32String, ChainId, ILogger, ProcessorEvent } from "@grants-stack-indexer/shared";
+import {
+    Bytes32String,
+    ChainId,
+    ILogger,
+    ProcessorEvent,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
 
 import { ProcessorDependencies } from "../../../src/internal.js";
 import { ProfileCreatedHandler } from "../../../src/processors/registry/handlers/index.js";
@@ -28,7 +34,7 @@ describe("ProfileCreatedHandler", () => {
     };
     beforeEach(() => {
         mockEvent = {
-            blockTimestamp: 123123123,
+            blockTimestamp: 123123123 as TimestampMs,
             chainId: 10 as ChainId,
             contractName: "Registry",
             eventName: "ProfileCreated",

--- a/packages/processors/test/registry/handlers/profileNameUpdated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileNameUpdated.handler.spec.ts
@@ -2,7 +2,7 @@ import { getAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 import { Changeset } from "@grants-stack-indexer/repository";
-import { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+import { Bytes32String, ChainId, ProcessorEvent, TimestampMs } from "@grants-stack-indexer/shared";
 
 import { ProfileNameUpdatedHandler } from "../../../src/processors/registry/handlers/profileNameUpdated.handler.js";
 
@@ -16,7 +16,7 @@ describe("ProfileNameUpdatedHandler", () => {
             anchor: "0x5aD1D85Bb68791Cb3cE598f56E00F5D5694FAd14",
         },
         blockNumber: 1,
-        blockTimestamp: 1,
+        blockTimestamp: 1 as TimestampMs,
         chainId: 1 as ChainId,
         logIndex: 1,
         srcAddress: "0x0",

--- a/packages/processors/test/registry/handlers/profileOwnerUpdated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileOwnerUpdated.handler.spec.ts
@@ -9,7 +9,7 @@ describe("ProfileOwnerUpdatedHandler", () => {
     it("handles ProfileOwnerUpdated event correctly", async () => {
         const mockEvent: ProcessorEvent<"Registry", "ProfileOwnerUpdated"> = {
             blockNumber: 123456,
-            blockTimestamp: 123456 as TimestampMs,
+            blockTimestamp: 1234560000000 as TimestampMs,
             chainId: 1 as ChainId,
             contractName: "Registry",
             eventName: "ProfileOwnerUpdated",

--- a/packages/processors/test/registry/handlers/profileOwnerUpdated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileOwnerUpdated.handler.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { Changeset } from "@grants-stack-indexer/repository";
-import { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+import { Bytes32String, ChainId, ProcessorEvent, TimestampMs } from "@grants-stack-indexer/shared";
 
 import { ProfileOwnerUpdatedHandler } from "../../../src/processors/registry/handlers/profileOwnerUpdated.handler.js";
 
@@ -9,7 +9,7 @@ describe("ProfileOwnerUpdatedHandler", () => {
     it("handles ProfileOwnerUpdated event correctly", async () => {
         const mockEvent: ProcessorEvent<"Registry", "ProfileOwnerUpdated"> = {
             blockNumber: 123456,
-            blockTimestamp: 123456,
+            blockTimestamp: 123456 as TimestampMs,
             chainId: 1 as ChainId,
             contractName: "Registry",
             eventName: "ProfileOwnerUpdated",

--- a/packages/processors/test/strategy/common/base.strategy.spec.ts
+++ b/packages/processors/test/strategy/common/base.strategy.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { Changeset } from "@grants-stack-indexer/repository";
-import { Address, Token, TokenCode } from "@grants-stack-indexer/shared";
+import { Address, TimestampMs, Token, TokenCode } from "@grants-stack-indexer/shared";
 
 import { BaseStrategyHandler } from "../../../src/processors/strategy/common/base.strategy.js";
 
@@ -46,7 +46,7 @@ describe("BaseStrategyHandler", () => {
                 code: "ETH" as TokenCode,
                 priceSourceCode: "ETH" as TokenCode,
             };
-            const blockTimestamp = 1625097600; // Example timestamp
+            const blockTimestamp = 1625097600 as TimestampMs; // Example timestamp
 
             const result = await handler.fetchMatchAmount(
                 matchingFundsAvailable,

--- a/packages/processors/test/strategy/common/base.strategy.spec.ts
+++ b/packages/processors/test/strategy/common/base.strategy.spec.ts
@@ -46,7 +46,7 @@ describe("BaseStrategyHandler", () => {
                 code: "ETH" as TokenCode,
                 priceSourceCode: "ETH" as TokenCode,
             };
-            const blockTimestamp = 1625097600 as TimestampMs; // Example timestamp
+            const blockTimestamp = 1625097600000 as TimestampMs; // Example timestamp
 
             const result = await handler.fetchMatchAmount(
                 matchingFundsAvailable,

--- a/packages/processors/test/strategy/directGrantsLite/handlers/allocated.handler.spec.ts
+++ b/packages/processors/test/strategy/directGrantsLite/handlers/allocated.handler.spec.ts
@@ -10,7 +10,7 @@ import {
     Round,
     RoundNotFound,
 } from "@grants-stack-indexer/repository";
-import { ChainId, ProcessorEvent, UnknownToken } from "@grants-stack-indexer/shared";
+import { ChainId, ProcessorEvent, TimestampMs, UnknownToken } from "@grants-stack-indexer/shared";
 
 import { TokenPriceNotFoundError } from "../../../../src/exceptions/tokenPriceNotFound.exception.js";
 import { DGLiteAllocatedHandler } from "../../../../src/processors/strategy/directGrantsLite/handlers/allocated.handler.js";
@@ -76,7 +76,7 @@ describe("DGLiteAllocatedHandler", () => {
             "getApplicationByAnchorAddressOrThrow",
         ).mockResolvedValue(mockApplication);
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
-            timestampMs: 1000000000,
+            timestampMs: 1000000000 as TimestampMs,
             priceUsd: 2000,
         });
 
@@ -349,11 +349,11 @@ describe("DGLiteAllocatedHandler", () => {
         ).mockResolvedValue(mockApplication);
         vi.spyOn(mockPricingProvider, "getTokenPrice")
             .mockResolvedValueOnce({
-                timestampMs: 1000000000,
+                timestampMs: 1000000000 as TimestampMs,
                 priceUsd: 1,
             })
             .mockResolvedValueOnce({
-                timestampMs: 1000000000,
+                timestampMs: 1000000000 as TimestampMs,
                 priceUsd: 2000,
             });
 

--- a/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/dvmdDirectTransfer.handler.spec.ts
+++ b/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/dvmdDirectTransfer.handler.spec.ts
@@ -14,6 +14,7 @@ import {
     ILogger,
     ProcessorEvent,
     StrategyEvent,
+    TimestampMs,
     Token,
     TokenCode,
 } from "@grants-stack-indexer/shared";
@@ -311,7 +312,7 @@ describe("DVMDDirectTransferHandler", () => {
                 code: "ETH" as TokenCode,
                 priceSourceCode: "ETH" as TokenCode,
             };
-            const blockTimestamp = 1625097600;
+            const blockTimestamp = 1625097600 as TimestampMs;
 
             vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
                 priceUsd: 2000,
@@ -338,7 +339,7 @@ describe("DVMDDirectTransferHandler", () => {
                 code: "ETH" as TokenCode,
                 priceSourceCode: "ETH" as TokenCode,
             };
-            const blockTimestamp = 1625097600;
+            const blockTimestamp = 1625097600 as TimestampMs;
 
             vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue(undefined);
 

--- a/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/handlers/allocated.handler.spec.ts
+++ b/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/handlers/allocated.handler.spec.ts
@@ -10,7 +10,7 @@ import {
     Round,
     RoundNotFound,
 } from "@grants-stack-indexer/repository";
-import { ChainId, ProcessorEvent, UnknownToken } from "@grants-stack-indexer/shared";
+import { ChainId, ProcessorEvent, TimestampMs, UnknownToken } from "@grants-stack-indexer/shared";
 
 import {
     MetadataParsingFailed,
@@ -78,7 +78,7 @@ describe("DVMDAllocatedHandler", () => {
             "getApplicationByAnchorAddressOrThrow",
         ).mockResolvedValue(mockApplication);
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
-            timestampMs: 1000000000,
+            timestampMs: 1000000000 as TimestampMs,
             priceUsd: 2000,
         });
 
@@ -142,13 +142,14 @@ describe("DVMDAllocatedHandler", () => {
             mockApplicationRepository,
             "getApplicationByAnchorAddressOrThrow",
         ).mockResolvedValue(mockApplication);
+        const timestampMs = 1000000000 as TimestampMs;
         vi.spyOn(mockPricingProvider, "getTokenPrice")
             .mockResolvedValueOnce({
-                timestampMs: 1000000000,
+                timestampMs,
                 priceUsd: 1,
             })
             .mockResolvedValueOnce({
-                timestampMs: 1000000000,
+                timestampMs,
                 priceUsd: 2000,
             });
 
@@ -170,7 +171,7 @@ describe("DVMDAllocatedHandler", () => {
                         amount: BigInt(amount),
                         amountInUsd: "1500",
                         amountInRoundMatchToken: parseEther("0.75"),
-                        timestamp: new Date(1000000000),
+                        timestamp: new Date(timestampMs),
                     }),
                 },
             },
@@ -348,7 +349,7 @@ describe("DVMDAllocatedHandler", () => {
             "getApplicationByAnchorAddressOrThrow",
         ).mockResolvedValue(mockApplication);
         vi.spyOn(mockPricingProvider, "getTokenPrice").mockResolvedValue({
-            timestampMs: 1000000000,
+            timestampMs: 1000000000 as TimestampMs,
             priceUsd: 2000,
         });
 

--- a/packages/repository/src/repositories/kysely/prices.repository.ts
+++ b/packages/repository/src/repositories/kysely/prices.repository.ts
@@ -1,10 +1,10 @@
 import { Kysely } from "kysely";
 
-import { TokenCode, TokenPrice } from "@grants-stack-indexer/shared";
+import { TimestampMs, TokenCode, TokenPrice } from "@grants-stack-indexer/shared";
 
 import { Database, handlePostgresError, ICache } from "../../internal.js";
 
-export type PriceCacheKey = { tokenCode: TokenCode; timestampMs: number };
+export type PriceCacheKey = { tokenCode: TokenCode; timestampMs: TimestampMs };
 
 /**
  * A cache for token prices using Kysely.
@@ -19,7 +19,10 @@ export class KyselyPricingCache implements ICache<PriceCacheKey, TokenPrice> {
     ) {}
 
     /** @inheritdoc */
-    async get(key: { tokenCode: TokenCode; timestampMs: number }): Promise<TokenPrice | undefined> {
+    async get(key: {
+        tokenCode: TokenCode;
+        timestampMs: TimestampMs;
+    }): Promise<TokenPrice | undefined> {
         const { tokenCode, timestampMs } = key;
 
         try {
@@ -36,7 +39,7 @@ export class KyselyPricingCache implements ICache<PriceCacheKey, TokenPrice> {
             }
 
             return {
-                timestampMs: result.timestampMs,
+                timestampMs: result.timestampMs as TimestampMs,
                 priceUsd: result.priceUsd,
             };
         } catch (error) {
@@ -52,7 +55,7 @@ export class KyselyPricingCache implements ICache<PriceCacheKey, TokenPrice> {
 
     /** @inheritdoc */
     async set(
-        key: { tokenCode: TokenCode; timestampMs: number },
+        key: { tokenCode: TokenCode; timestampMs: TimestampMs },
         value: TokenPrice,
     ): Promise<void> {
         const { tokenCode, timestampMs } = key;

--- a/packages/shared/src/tokens/tokens.ts
+++ b/packages/shared/src/tokens/tokens.ts
@@ -1,6 +1,6 @@
 import { Branded } from "viem";
 
-import { Address, ChainId } from "../internal.js";
+import { Address, ChainId, TimestampMs } from "../internal.js";
 
 export type TokenCode = Branded<string, "TokenCode">;
 
@@ -13,7 +13,7 @@ export type Token = {
 };
 
 export type TokenPrice = {
-    timestampMs: number;
+    timestampMs: TimestampMs;
     priceUsd: number;
 };
 

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -5,3 +5,5 @@ import { Branded } from "../internal.js";
 export type ChainId = Branded<number, "ChainId">;
 
 export type Bytes32String = Branded<Hex, "Bytes32String">;
+
+export type TimestampMs = Branded<number, "TimestampMs">;

--- a/packages/shared/src/types/events/common.ts
+++ b/packages/shared/src/types/events/common.ts
@@ -1,6 +1,6 @@
 import { Hex } from "viem";
 
-import { Address } from "../../internal.js";
+import { Address, TimestampMs } from "../../internal.js";
 import {
     AlloEvent,
     AlloEventParams,
@@ -53,7 +53,7 @@ export type EventParams<T extends ContractName, E extends ContractToEventName<T>
 export type IndexerFetchedEvent<T extends ContractName, E extends ContractToEventName<T>> = {
     //TODO: make blocknumber and chainId bigints, implies implementing adapter patterns in the EventsFetcher or IndexerClient
     blockNumber: number;
-    blockTimestamp: number;
+    blockTimestamp: TimestampMs;
     chainId: number;
     contractName: T;
     eventName: E;

--- a/scripts/migrations/src/migrations/20241216T160549_event_registry.ts
+++ b/scripts/migrations/src/migrations/20241216T160549_event_registry.ts
@@ -13,7 +13,7 @@ export async function up(db: Kysely<any>): Promise<void> {
         .createTable("events_registry")
         .addColumn("chainId", CHAIN_ID_TYPE)
         .addColumn("blockNumber", "integer")
-        .addColumn("blockTimestamp", "integer")
+        .addColumn("blockTimestamp", "bigint")
         .addColumn("logIndex", "integer")
         .addColumn("rawEvent", "jsonb")
         .addPrimaryKeyConstraint("events_registry_pkey", ["chainId"])

--- a/scripts/migrations/src/migrations/20250127T000000_add_cache_tables.ts
+++ b/scripts/migrations/src/migrations/20250127T000000_add_cache_tables.ts
@@ -5,7 +5,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     await db.schema
         .createTable("priceCache")
         .addColumn("tokenCode", "text", (col) => col.notNull())
-        .addColumn("timestampMs", "integer", (col) => col.notNull())
+        .addColumn("timestampMs", "bigint", (col) => col.notNull())
         .addColumn("priceUsd", "decimal(36, 18)", (col) => col.notNull())
         .addColumn("createdAt", "timestamptz", (col) => col.defaultTo(sql`now()`))
         .addPrimaryKeyConstraint("pricing_cache_pkey", ["tokenCode", "timestampMs"])


### PR DESCRIPTION
# 🤖 Linear

Closes GIT-171

## Description
`block.timestamp` is treated as Unix timestamp in seconds, reason why Envio client returns it as that. However, the system manages Unix timestamp in milliseconds to be compliant with Javascript treatment in Date objects (and it's also more usual to work it like this) and also with external providers like Coingecko that also manages timestamps in ms.

To fix this, we convert timestamps to MS in Envio indexer client. Also, we create a branded type TimestampMs.


## Checklist before requesting a review

-   [x] I have conducted a self-review of my code.
-   [x] I have conducted a QA.
-   [x] If it is a core feature, I have included comprehensive tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Here are the release notes for this pull request:

- **Type Safety Improvements**
    - Introduced `TimestampMs` type for more precise timestamp handling across multiple packages.
    - Updated timestamp-related method signatures to use `TimestampMs`, enhancing clarity and type safety.

- **Database Schema Updates**
    - Modified `blockTimestamp` and `timestampMs` column types to `bigint` in migration scripts, supporting larger timestamp values for improved data representation.

- **Code Consistency**
    - Standardized timestamp type usage in pricing, processing, and indexing components.
    - Enhanced type definitions for event and token price data structures, ensuring consistency across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->