### PR TITLE
feat: make saveLastProcessedEvent part of transaction

### DIFF
--- a/apps/processing/src/services/processing.service.ts
+++ b/apps/processing/src/services/processing.service.ts
@@ -4,7 +4,6 @@ import { EvmProvider } from "@grants-stack-indexer/chain-providers";
 import {
     DatabaseEventRegistry,
     DatabaseStrategyRegistry,
-    InMemoryCachedEventRegistry,
     InMemoryCachedStrategyRegistry,
     Orchestrator,
     RetroactiveProcessor,
@@ -67,12 +66,6 @@ export class ProcessingService {
             // Initialize EVM provider
             const evmProvider = new EvmProvider(chain.rpcUrls, optimism, logger);
 
-            // Initialize events registry for the chain
-            const cachedEventsRegistry = await InMemoryCachedEventRegistry.initialize(
-                logger,
-                eventsRegistry,
-                [chain.id as ChainId],
-            );
             const cachedStrategyRegistry = await InMemoryCachedStrategyRegistry.initialize(
                 logger,
                 strategyRegistry,
@@ -84,7 +77,7 @@ export class ProcessingService {
                 { ...core, evmProvider },
                 indexerClient,
                 {
-                    eventsRegistry: cachedEventsRegistry,
+                    eventsRegistry,
                     strategyRegistry: cachedStrategyRegistry,
                 },
                 chain.fetchLimit,
@@ -97,7 +90,7 @@ export class ProcessingService {
                 { ...core, evmProvider },
                 indexerClient,
                 {
-                    eventsRegistry: cachedEventsRegistry,
+                    eventsRegistry,
                     strategyRegistry: cachedStrategyRegistry,
                     checkpointRepository: strategyProcessingCheckpointRepository,
                 },

--- a/apps/processing/test/unit/processing.service.spec.ts
+++ b/apps/processing/test/unit/processing.service.spec.ts
@@ -4,7 +4,6 @@ import { EvmProvider } from "@grants-stack-indexer/chain-providers";
 import {
     DatabaseEventRegistry,
     DatabaseStrategyRegistry,
-    InMemoryCachedEventRegistry,
     InMemoryCachedStrategyRegistry,
     Orchestrator,
     RetroactiveProcessor,
@@ -118,7 +117,6 @@ describe("ProcessingService", () => {
             expect(DatabaseEventRegistry).toHaveBeenCalledTimes(1);
             expect(EvmProvider).toHaveBeenCalledTimes(2);
             expect(InMemoryCachedStrategyRegistry.initialize).toHaveBeenCalledTimes(2);
-            expect(InMemoryCachedEventRegistry.initialize).toHaveBeenCalledTimes(2);
 
             // Verify orchestrators were created with correct parameters
             expect(processingService["orchestrators"].size).toBe(2);

--- a/packages/data-flow/src/data-loader/dataLoader.ts
+++ b/packages/data-flow/src/data-loader/dataLoader.ts
@@ -3,6 +3,7 @@ import {
     IApplicationPayoutRepository,
     IApplicationRepository,
     IDonationRepository,
+    IEventRegistryRepository,
     IProjectRepository,
     IRoundRepository,
     ITransactionManager,
@@ -17,6 +18,7 @@ import {
     createProjectHandlers,
     createRoundHandlers,
 } from "./handlers/index.js";
+import { createProcessedEventHandlers } from "./handlers/processedEvent.handlers.js";
 import { ChangesetHandlers } from "./types/index.js";
 
 /**
@@ -42,6 +44,7 @@ export class DataLoader implements IDataLoader {
             application: IApplicationRepository;
             donation: IDonationRepository;
             applicationPayout: IApplicationPayoutRepository;
+            eventRegistry: IEventRegistryRepository;
         },
         private readonly transactionManager: ITransactionManager,
         private readonly logger: ILogger,
@@ -52,6 +55,7 @@ export class DataLoader implements IDataLoader {
             ...createApplicationHandlers(repositories.application),
             ...createDonationHandlers(repositories.donation),
             ...createApplicationPayoutHandlers(repositories.applicationPayout),
+            ...createProcessedEventHandlers(repositories.eventRegistry),
         };
     }
 

--- a/packages/data-flow/src/data-loader/handlers/index.ts
+++ b/packages/data-flow/src/data-loader/handlers/index.ts
@@ -3,3 +3,4 @@ export * from "./project.handlers.js";
 export * from "./round.handlers.js";
 export * from "./donation.handlers.js";
 export * from "./applicationPayout.handlers.js";
+export * from "./processedEvent.handlers.js";

--- a/packages/data-flow/src/data-loader/handlers/processedEvent.handlers.ts
+++ b/packages/data-flow/src/data-loader/handlers/processedEvent.handlers.ts
@@ -1,0 +1,32 @@
+import {
+    IEventRegistryRepository,
+    ProcessedEventChangeset,
+} from "@grants-stack-indexer/repository";
+
+import { ChangesetHandler } from "../types/index.js";
+
+/**
+ * Collection of handlers for application-related operations.
+ * Each handler corresponds to a specific Application changeset type.
+ */
+export type ProcessedEventHandlers = {
+    [K in ProcessedEventChangeset["type"]]: ChangesetHandler<K>;
+};
+
+/**
+ * Creates handlers for managing application-related operations.
+ *
+ * @param repository - The application repository instance used for database operations
+ * @returns An object containing all application-related handlers
+ */
+export const createProcessedEventHandlers = (
+    repository: IEventRegistryRepository,
+): ProcessedEventHandlers => ({
+    InsertProcessedEvent: (async (changeset, txConnection): Promise<void> => {
+        await repository.saveLastProcessedEvent(
+            changeset.args.chainId,
+            changeset.args.processedEvent,
+            txConnection,
+        );
+    }) satisfies ChangesetHandler<"InsertProcessedEvent">,
+});

--- a/packages/data-flow/src/orchestrator.ts
+++ b/packages/data-flow/src/orchestrator.ts
@@ -7,7 +7,12 @@ import {
     UnsupportedEventException,
     UnsupportedStrategy,
 } from "@grants-stack-indexer/processors";
-import { RoundNotFound, RoundNotFoundForId } from "@grants-stack-indexer/repository";
+import {
+    Changeset,
+    IEventRegistryRepository,
+    RoundNotFound,
+    RoundNotFoundForId,
+} from "@grants-stack-indexer/repository";
 import {
     Address,
     AnyEvent,
@@ -29,7 +34,7 @@ import {
     Token,
 } from "@grants-stack-indexer/shared";
 
-import type { IEventsFetcher, IEventsRegistry, IStrategyRegistry } from "./interfaces/index.js";
+import type { IEventsFetcher, IStrategyRegistry } from "./interfaces/index.js";
 import { EventsFetcher } from "./eventsFetcher.js";
 import { EventsProcessor } from "./eventsProcessor.js";
 import { InvalidEvent } from "./exceptions/index.js";
@@ -72,7 +77,7 @@ export class Orchestrator {
     private readonly eventsByBlockContext: Map<number, AnyIndexerFetchedEvent[]>;
     private readonly eventsFetcher: IEventsFetcher;
     private readonly eventsProcessor: EventsProcessor;
-    private readonly eventsRegistry: IEventsRegistry;
+    private readonly eventsRegistry: IEventRegistryRepository;
     private readonly strategyRegistry: IStrategyRegistry;
     private readonly dataLoader: DataLoader;
     private readonly retryHandler: RetryHandler;
@@ -91,7 +96,7 @@ export class Orchestrator {
         private dependencies: Readonly<CoreDependencies>,
         private indexerClient: IIndexerClient,
         private registries: {
-            eventsRegistry: IEventsRegistry;
+            eventsRegistry: IEventRegistryRepository;
             strategyRegistry: IStrategyRegistry;
         },
         private fetchLimit: number = 1000,
@@ -113,6 +118,7 @@ export class Orchestrator {
                 application: this.dependencies.applicationRepository,
                 donation: this.dependencies.donationRepository,
                 applicationPayout: this.dependencies.applicationPayoutRepository,
+                eventRegistry: this.eventsRegistry,
             },
             this.dependencies.transactionManager,
             this.logger,
@@ -146,18 +152,34 @@ export class Orchestrator {
                     continue;
                 }
 
-                await this.eventsRegistry.saveLastProcessedEvent(this.chainId, {
-                    ...event,
-                    rawEvent: event,
-                });
-
                 await this.retryHandler.execute(
                     async () => {
-                        await this.handleEvent(event!);
+                        const changesets = await this.handleEvent(event!);
+                        if (changesets) {
+                            await this.dataLoader.applyChanges([
+                                ...changesets,
+                                {
+                                    type: "InsertProcessedEvent",
+                                    args: {
+                                        chainId: this.chainId,
+                                        processedEvent: {
+                                            ...event!,
+                                            rawEvent: event,
+                                        },
+                                    },
+                                },
+                            ]);
+                        }
                     },
                     { abortSignal: signal },
                 );
             } catch (error: unknown) {
+                if (event) {
+                    await this.eventsRegistry.saveLastProcessedEvent(this.chainId, {
+                        ...event,
+                        rawEvent: event,
+                    });
+                }
                 // TODO: notify
                 if (
                     error instanceof UnsupportedStrategy ||
@@ -403,7 +425,9 @@ export class Orchestrator {
         return tokenPrices;
     }
 
-    private async handleEvent(event: ProcessorEvent<ContractName, AnyEvent>): Promise<void> {
+    private async handleEvent(
+        event: ProcessorEvent<ContractName, AnyEvent>,
+    ): Promise<Changeset[] | undefined> {
         event = await this.enhanceStrategyId(event);
         if (this.isPoolCreated(event)) {
             const handleable = existsHandler(event.strategyId);
@@ -421,12 +445,11 @@ export class Orchestrator {
                     chainId: this.chainId,
                 });
                 // we skip the event if the strategy id is not handled yet
-                return;
+                return undefined;
             }
         }
 
-        const changesets = await this.eventsProcessor.processEvent(event);
-        await this.dataLoader.applyChanges(changesets);
+        return this.eventsProcessor.processEvent(event);
     }
 
     /**

--- a/packages/data-flow/src/retroactiveProcessor.ts
+++ b/packages/data-flow/src/retroactiveProcessor.ts
@@ -1,6 +1,9 @@
 import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
 import { existsHandler, UnsupportedEventException } from "@grants-stack-indexer/processors";
-import { IStrategyProcessingCheckpointRepository } from "@grants-stack-indexer/repository";
+import {
+    IEventRegistryRepository,
+    IStrategyProcessingCheckpointRepository,
+} from "@grants-stack-indexer/repository";
 import {
     Address,
     AnyEvent,
@@ -20,7 +23,6 @@ import {
     EventsFetcher,
     EventsProcessor,
     IEventsFetcher,
-    IEventsRegistry,
     InvalidEvent,
     IStrategyRegistry,
     Queue,
@@ -60,7 +62,7 @@ type EventPointer = {
 export class RetroactiveProcessor {
     private readonly eventsFetcher: IEventsFetcher;
     private readonly eventsProcessor: EventsProcessor;
-    private readonly eventsRegistry: IEventsRegistry;
+    private readonly eventsRegistry: IEventRegistryRepository;
     private readonly strategyRegistry: IStrategyRegistry;
     private readonly dataLoader: DataLoader;
     private readonly checkpointRepository: IStrategyProcessingCheckpointRepository;
@@ -81,7 +83,7 @@ export class RetroactiveProcessor {
         private dependencies: Readonly<CoreDependencies>,
         private indexerClient: IIndexerClient,
         private registries: {
-            eventsRegistry: IEventsRegistry;
+            eventsRegistry: IEventRegistryRepository;
             strategyRegistry: IStrategyRegistry;
             checkpointRepository: IStrategyProcessingCheckpointRepository;
         },
@@ -104,6 +106,7 @@ export class RetroactiveProcessor {
                 application: this.dependencies.applicationRepository,
                 donation: this.dependencies.donationRepository,
                 applicationPayout: this.dependencies.applicationPayoutRepository,
+                eventRegistry: this.eventsRegistry,
             },
             this.dependencies.transactionManager,
             this.logger,

--- a/packages/data-flow/test/data-loader/dataLoader.spec.ts
+++ b/packages/data-flow/test/data-loader/dataLoader.spec.ts
@@ -5,6 +5,7 @@ import {
     IApplicationPayoutRepository,
     IApplicationRepository,
     IDonationRepository,
+    IEventRegistryRepository,
     IProjectRepository,
     IRoundRepository,
     ITransactionManager,
@@ -41,6 +42,10 @@ describe("DataLoader", () => {
         insertApplicationPayout: vi.fn(),
     } as IApplicationPayoutRepository;
 
+    const mockEventRegistryRepository = {
+        saveLastProcessedEvent: vi.fn(),
+    } as unknown as IEventRegistryRepository;
+
     const logger: ILogger = {
         debug: vi.fn(),
         error: vi.fn(),
@@ -61,6 +66,7 @@ describe("DataLoader", () => {
                 application: mockApplicationRepository,
                 donation: mockDonationRepository,
                 applicationPayout: mockApplicationPayoutRepository,
+                eventRegistry: mockEventRegistryRepository,
             },
             mockTransactionManager,
             logger,

--- a/packages/data-flow/test/data-loader/handlers/processedEvent.handlers.spec.ts
+++ b/packages/data-flow/test/data-loader/handlers/processedEvent.handlers.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { IEventRegistryRepository, TransactionConnection } from "@grants-stack-indexer/repository";
+import { ChainId } from "@grants-stack-indexer/shared";
+
+import { createProcessedEventHandlers } from "../../../src/data-loader/handlers/processedEvent.handlers.js";
+
+describe("ProcessedEvent Handlers", () => {
+    const chainId = 1 as ChainId;
+    const mockEvent = {
+        blockNumber: 1,
+        blockTimestamp: 1234567890,
+        logIndex: 0,
+        rawEvent: {},
+    };
+
+    describe("InsertProcessedEvent", () => {
+        it("saves event to repository within transaction", async () => {
+            const saveLastProcessedEvent = vi.fn();
+            const mockRepository = {
+                saveLastProcessedEvent,
+                getLastProcessedEvent: vi.fn(),
+            } as unknown as IEventRegistryRepository<TransactionConnection>;
+
+            const handlers = createProcessedEventHandlers(mockRepository);
+
+            const mockTx = {} as TransactionConnection;
+
+            await handlers.InsertProcessedEvent(
+                {
+                    type: "InsertProcessedEvent",
+                    args: {
+                        chainId,
+                        processedEvent: mockEvent,
+                    },
+                },
+                mockTx,
+            );
+
+            expect(saveLastProcessedEvent).toHaveBeenCalledWith(chainId, mockEvent, mockTx);
+        });
+
+        it("propagates repository errors", async () => {
+            const error = new Error("Database error");
+            const saveLastProcessedEvent = vi.fn().mockRejectedValue(error);
+            const mockRepository = {
+                saveLastProcessedEvent,
+                getLastProcessedEvent: vi.fn(),
+            } as unknown as IEventRegistryRepository<TransactionConnection>;
+
+            const handlers = createProcessedEventHandlers(mockRepository);
+
+            const mockTx = {} as TransactionConnection;
+
+            await expect(
+                handlers.InsertProcessedEvent(
+                    {
+                        type: "InsertProcessedEvent",
+                        args: {
+                            chainId,
+                            processedEvent: mockEvent,
+                        },
+                    },
+                    mockTx,
+                ),
+            ).rejects.toThrow(error);
+        });
+    });
+});

--- a/packages/data-flow/test/unit/orchestrator.spec.ts
+++ b/packages/data-flow/test/unit/orchestrator.spec.ts
@@ -10,12 +10,13 @@ import {
     IApplicationPayoutRepository,
     IApplicationRepository,
     IDonationRepository,
+    IEventRegistryRepository,
     IProjectRepository,
     IRoundRepository,
     ITransactionManager,
     RoundNotFound,
+    RoundNotFoundForId,
 } from "@grants-stack-indexer/repository";
-import { RoundNotFoundForId } from "@grants-stack-indexer/repository/dist/src/internal.js";
 import {
     AlloEvent,
     AnyIndexerFetchedEvent,
@@ -35,12 +36,7 @@ import {
     TokenCode,
 } from "@grants-stack-indexer/shared";
 
-import {
-    CoreDependencies,
-    IEventsRegistry,
-    InvalidEvent,
-    IStrategyRegistry,
-} from "../../src/internal.js";
+import { CoreDependencies, InvalidEvent, IStrategyRegistry } from "../../src/internal.js";
 import { Orchestrator } from "../../src/orchestrator.js";
 
 vi.mock("../../src/eventsProcessor.js", () => {
@@ -63,8 +59,8 @@ vi.mock("../../src/data-loader/dataLoader.js", () => {
 describe("Orchestrator", { sequential: true }, () => {
     let orchestrator: Orchestrator;
     let mockIndexerClient: IIndexerClient;
-    let mockEventsRegistry: IEventsRegistry;
     let mockStrategyRegistry: IStrategyRegistry;
+    let mockEventsRegistry: IEventRegistryRepository;
     let mockPricingProvider: IPricingProvider & ICacheable;
     let mockMetadataProvider: IMetadataProvider & ICacheable;
     let mockEvmProvider: EvmProvider;
@@ -90,7 +86,7 @@ describe("Orchestrator", { sequential: true }, () => {
         mockEventsRegistry = {
             getLastProcessedEvent: vi.fn(),
             saveLastProcessedEvent: vi.fn(),
-        };
+        } as unknown as IEventRegistryRepository;
 
         mockStrategyRegistry = {
             getStrategyId: vi.fn(),
@@ -175,12 +171,6 @@ describe("Orchestrator", { sequential: true }, () => {
             vi.spyOn(orchestrator["dataLoader"], "applyChanges").mockResolvedValue(
                 await Promise.resolve(),
             );
-            vi.spyOn(mockEventsRegistry, "saveLastProcessedEvent").mockImplementation(() => {
-                return Promise.resolve();
-            });
-            vi.spyOn(mockStrategyRegistry, "saveStrategyId").mockImplementation(() => {
-                return Promise.resolve();
-            });
 
             runPromise = orchestrator.run(abortController.signal);
 
@@ -195,7 +185,8 @@ describe("Orchestrator", { sequential: true }, () => {
 
             expect(eventsProcessorSpy).toHaveBeenCalledWith(mockEvents[0]);
             expect(eventsProcessorSpy).toHaveBeenCalledWith(mockEvents[1]);
-            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalledTimes(2);
+            expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledTimes(2);
+            expect(mockEventsRegistry.saveLastProcessedEvent).not.toHaveBeenCalled();
         });
 
         it("wait and keep polling on empty queue", async () => {
@@ -216,6 +207,108 @@ describe("Orchestrator", { sequential: true }, () => {
             expect(
                 getEventsAfterBlockNumberAndLogIndexSpy.mock.calls.length,
             ).toBeGreaterThanOrEqual(3);
+        });
+
+        it("includes InsertProcessedEvent changeset in transaction", async () => {
+            const mockEvent = createMockEvent("Registry", "ProfileCreated", 1);
+            const changesets = [
+                {
+                    type: "InsertProject",
+                    args: { chainId, projectId: "1", project: {} },
+                } as unknown as Changeset,
+            ];
+
+            const eventsProcessorSpy = vi.spyOn(orchestrator["eventsProcessor"], "processEvent");
+            const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+
+            vi.spyOn(mockEventsRegistry, "getLastProcessedEvent").mockResolvedValue(undefined);
+            vi.spyOn(mockIndexerClient, "getEventsAfterBlockNumberAndLogIndex")
+                .mockResolvedValueOnce([mockEvent])
+                .mockResolvedValue([]);
+
+            eventsProcessorSpy.mockResolvedValue(changesets);
+
+            runPromise = orchestrator.run(abortController.signal);
+
+            await vi.waitFor(() => {
+                if (eventsProcessorSpy.mock.calls.length < 1) throw new Error("Not yet called");
+            });
+
+            expect(dataLoaderSpy).toHaveBeenCalledWith([
+                ...changesets,
+                {
+                    type: "InsertProcessedEvent",
+                    args: {
+                        chainId,
+                        processedEvent: {
+                            ...mockEvent,
+                            rawEvent: mockEvent,
+                        },
+                    },
+                },
+            ]);
+            expect(mockEventsRegistry.saveLastProcessedEvent).not.toHaveBeenCalled();
+        });
+
+        it("saves event outside transaction when processing fails", async () => {
+            const mockEvent = createMockEvent("Registry", "ProfileCreated", 1);
+            const error = new Error("Processing failed");
+
+            const eventsProcessorSpy = vi.spyOn(orchestrator["eventsProcessor"], "processEvent");
+            const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+
+            vi.spyOn(mockEventsRegistry, "getLastProcessedEvent").mockResolvedValue(undefined);
+            vi.spyOn(mockIndexerClient, "getEventsAfterBlockNumberAndLogIndex")
+                .mockResolvedValueOnce([mockEvent])
+                .mockResolvedValue([]);
+
+            eventsProcessorSpy.mockRejectedValue(error);
+
+            runPromise = orchestrator.run(abortController.signal);
+
+            await vi.waitFor(() => {
+                if (eventsProcessorSpy.mock.calls.length < 1) throw new Error("Not yet called");
+            });
+
+            expect(dataLoaderSpy).not.toHaveBeenCalled();
+            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(chainId, {
+                ...mockEvent,
+                rawEvent: mockEvent,
+            });
+        });
+
+        it("rolls back transaction on error", async () => {
+            const mockEvent = createMockEvent("Registry", "ProfileCreated", 1);
+            const changesets = [
+                {
+                    type: "InsertProject",
+                    args: { chainId, projectId: "1", project: {} },
+                } as unknown as Changeset,
+            ];
+            const error = new Error("Transaction failed");
+
+            const eventsProcessorSpy = vi.spyOn(orchestrator["eventsProcessor"], "processEvent");
+            const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+
+            vi.spyOn(mockEventsRegistry, "getLastProcessedEvent").mockResolvedValue(undefined);
+            vi.spyOn(mockIndexerClient, "getEventsAfterBlockNumberAndLogIndex")
+                .mockResolvedValueOnce([mockEvent])
+                .mockResolvedValue([]);
+
+            eventsProcessorSpy.mockResolvedValue(changesets);
+            dataLoaderSpy.mockRejectedValue(error);
+
+            runPromise = orchestrator.run(abortController.signal);
+
+            await vi.waitFor(() => {
+                if (eventsProcessorSpy.mock.calls.length < 1) throw new Error("Not yet called");
+            });
+
+            expect(dataLoaderSpy).toHaveBeenCalled();
+            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(chainId, {
+                ...mockEvent,
+                rawEvent: mockEvent,
+            });
         });
     });
 
@@ -279,8 +372,9 @@ describe("Orchestrator", { sequential: true }, () => {
                 strategyId,
             });
             expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledTimes(1);
-            expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(changesets);
-            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalled();
+            expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+                expect.arrayContaining(changesets),
+            );
         });
 
         it("save strategyId to registry on PoolCreated event", async () => {
@@ -407,8 +501,19 @@ describe("Orchestrator", { sequential: true }, () => {
                     strategyAddress,
                 );
                 expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledTimes(1);
-                expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(changesets);
-                expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalled();
+                expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith([
+                    ...changesets,
+                    {
+                        type: "InsertProcessedEvent",
+                        args: {
+                            chainId,
+                            processedEvent: {
+                                ...mockEvent,
+                                rawEvent: mockEvent,
+                            },
+                        },
+                    },
+                ]);
             });
         }
 
@@ -592,7 +697,6 @@ describe("Orchestrator", { sequential: true }, () => {
 
             expect(eventsProcessorSpy).toHaveBeenCalledTimes(2);
             expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledTimes(1);
-            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalledTimes(1);
         });
 
         it("keeps running when there is an error", async () => {
@@ -626,7 +730,7 @@ describe("Orchestrator", { sequential: true }, () => {
 
             expect(eventsProcessorSpy).toHaveBeenCalledTimes(2);
             expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledTimes(1);
-            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalledTimes(2);
+            expect(mockEventsRegistry.saveLastProcessedEvent).toHaveBeenCalledTimes(1);
             expect(logger.error).toHaveBeenCalledWith(error, {
                 className: Orchestrator.name,
                 chainId,

--- a/packages/repository/src/external.ts
+++ b/packages/repository/src/external.ts
@@ -48,6 +48,7 @@ export type {
     ApplicationChangeset,
     DonationChangeset,
     ApplicationPayoutChangeset,
+    ProcessedEventChangeset,
 } from "./types/index.js";
 
 export {

--- a/packages/repository/src/interfaces/eventsRepository.interface.ts
+++ b/packages/repository/src/interfaces/eventsRepository.interface.ts
@@ -1,8 +1,10 @@
 import { ChainId } from "@grants-stack-indexer/shared";
 
-import { NewProcessedEvent, ProcessedEvent } from "../types/index.js";
+import { NewProcessedEvent, ProcessedEvent, TransactionConnection } from "../types/index.js";
 
-export interface IEventRegistryRepository {
+export interface IEventRegistryRepository<
+    TxConnection extends TransactionConnection = TransactionConnection,
+> {
     /**
      * Get the last processed event for a given chain.
      * @param chainId - The chain ID.
@@ -15,5 +17,9 @@ export interface IEventRegistryRepository {
      * @param chainId - The chain ID.
      * @param event - The new processed event to save.
      */
-    saveLastProcessedEvent: (chainId: ChainId, event: NewProcessedEvent) => Promise<void>;
+    saveLastProcessedEvent: (
+        chainId: ChainId,
+        event: NewProcessedEvent,
+        txConnection?: TxConnection,
+    ) => Promise<void>;
 }

--- a/packages/repository/src/repositories/kysely/eventRegistry.repository.ts
+++ b/packages/repository/src/repositories/kysely/eventRegistry.repository.ts
@@ -6,11 +6,12 @@ import { IEventRegistryRepository } from "../../interfaces/index.js";
 import {
     Database,
     handlePostgresError,
+    KyselyTransaction,
     NewProcessedEvent,
     ProcessedEvent,
 } from "../../internal.js";
 
-export class KyselyEventRegistryRepository implements IEventRegistryRepository {
+export class KyselyEventRegistryRepository implements IEventRegistryRepository<KyselyTransaction> {
     constructor(
         private readonly db: Kysely<Database>,
         private readonly schemaName: string,
@@ -27,10 +28,14 @@ export class KyselyEventRegistryRepository implements IEventRegistryRepository {
     }
 
     /** @inheritdoc */
-    async saveLastProcessedEvent(chainId: ChainId, event: NewProcessedEvent): Promise<void> {
+    async saveLastProcessedEvent(
+        chainId: ChainId,
+        event: NewProcessedEvent,
+        txConnection?: KyselyTransaction,
+    ): Promise<void> {
         const { blockNumber, blockTimestamp, logIndex, rawEvent } = event; // Extract only the fields from NewProcessedEvent
         try {
-            await this.db
+            await (txConnection || this.db)
                 .withSchema(this.schemaName)
                 .insertInto("eventsRegistry")
                 .values({ blockNumber, blockTimestamp, logIndex, chainId, rawEvent })

--- a/packages/repository/src/types/changeset.types.ts
+++ b/packages/repository/src/types/changeset.types.ts
@@ -1,6 +1,6 @@
 import type { Address, ChainId } from "@grants-stack-indexer/shared";
 
-import { NewApplicationPayout } from "../internal.js";
+import { NewApplicationPayout, NewProcessedEvent } from "../internal.js";
 import { NewApplication, PartialApplication } from "./application.types.js";
 import { NewDonation } from "./donation.types.js";
 import {
@@ -167,9 +167,18 @@ export type ApplicationPayoutChangeset = {
     };
 };
 
+export type ProcessedEventChangeset = {
+    type: "InsertProcessedEvent";
+    args: {
+        chainId: ChainId;
+        processedEvent: NewProcessedEvent;
+    };
+};
+
 export type Changeset =
     | ProjectChangeset
     | RoundChangeset
     | ApplicationChangeset
     | DonationChangeset
-    | ApplicationPayoutChangeset;
+    | ApplicationPayoutChangeset
+    | ProcessedEventChangeset;


### PR DESCRIPTION
# 🤖 Linear

Closes GIT-232

## Description
We want to make last processed event part of the transaction on the happy path, so we increase reliability and error handling of the system.
For this we are:
- deprecating the InMemoryCache of EventRegistry
- work directly with IEventRegistryRepository implementations
- add optional txConnection to `saveLastProcessedEvent` method


## Checklist before requesting a review

-   [x] I have conducted a self-review of my code.
-   [x] I have conducted a QA.
-   [ ] If it is a core feature, I have included comprehensive tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced event registry handling with improved transaction support.
  - Added new processed event changeset type for more flexible event management.
  - Introduced processed event handlers for managing application-related operations.

- **Improvements**
  - Simplified event processing logic in orchestrators.
  - Updated data loader to support more comprehensive event handling.
  - Improved error handling for event processing workflows.

- **Technical Updates**
  - Refactored event registry interfaces and implementations.
  - Updated type definitions for better type safety and flexibility.
  - Expanded test coverage for processed event handlers and orchestrator functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->