### PR TITLE
test: allo & registry integration tests

### DIFF
--- a/packages/data-flow/test/integration/allo.integration.spec.ts
+++ b/packages/data-flow/test/integration/allo.integration.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
 import { IEventRegistryRepository, Round } from "@grants-stack-indexer/repository";
-import { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+import { Bytes32String, ChainId } from "@grants-stack-indexer/shared";
 
 import { CoreDependencies, IStrategyRegistry } from "../../src/internal.js";
 import { Orchestrator } from "../../src/orchestrator.js";
@@ -66,7 +66,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
                 strategy: "0xF5F6Ca46a9DA3C1089d0F2F029cF14F3F714D483",
                 profileId: "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b",
             },
-        }) as ProcessorEvent<"Allo", "PoolCreated">;
+        });
 
         const { indexerClient } = mocks;
         const { roundRepository, metadataProvider, evmProvider } = mocks.dependencies;
@@ -244,7 +244,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
                 poolId: "13",
                 metadata: ["1", "bafkreiadxn64e7ibijctm67flwgbjpsy36avvfsrmzyvraffnwsg75yki4"],
             },
-        }) as ProcessorEvent<"Allo", "PoolMetadataUpdated">;
+        });
 
         const { indexerClient } = mocks;
         const { roundRepository, metadataProvider } = mocks.dependencies;
@@ -325,7 +325,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Allo", "RoleGranted">;
+        });
 
         const { indexerClient } = mocks;
         const { roundRepository } = mocks.dependencies;
@@ -394,7 +394,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Allo", "RoleGranted">;
+        });
 
         const { indexerClient } = mocks;
         const { roundRepository } = mocks.dependencies;
@@ -452,7 +452,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Allo", "RoleRevoked">;
+        });
 
         const { indexerClient } = mocks;
         const { roundRepository } = mocks.dependencies;
@@ -518,7 +518,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Allo", "RoleRevoked">;
+        });
 
         const { indexerClient } = mocks;
         const { roundRepository } = mocks.dependencies;

--- a/packages/data-flow/test/integration/allo.integration.spec.ts
+++ b/packages/data-flow/test/integration/allo.integration.spec.ts
@@ -1,14 +1,18 @@
-import { zeroAddress } from "viem";
+import { parseUnits, zeroAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
-import { IEventRegistryRepository } from "@grants-stack-indexer/repository";
-import { ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+import { IEventRegistryRepository, Round } from "@grants-stack-indexer/repository";
+import { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
 
 import { CoreDependencies, IStrategyRegistry } from "../../src/internal.js";
 import { Orchestrator } from "../../src/orchestrator.js";
 import { DEFAULT_STRATEGY_MAP } from "./helpers/dependencies.js";
-import { createTestAlloEvent, DEFAULT_TIMESTAMP_MS } from "./helpers/eventFactory.js";
+import {
+    createTestAlloEvent,
+    DEFAULT_FROM_ADDRESS,
+    DEFAULT_TIMESTAMP_MS,
+} from "./helpers/eventFactory.js";
 import { createTestOrchestrator } from "./helpers/setup.js";
 import { waitForProcessing } from "./helpers/testing.js";
 
@@ -77,7 +81,7 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
         vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
             .mockResolvedValueOnce([poolCreatedEvent])
             .mockResolvedValue([]);
-        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue(undefined);
+        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue({});
         vi.spyOn(evmProvider, "readContract").mockResolvedValue(strategyTiming);
         vi.spyOn(roundRepository, "getPendingRoundRoles").mockImplementation((_, name) => {
             if (name === "admin") {
@@ -164,6 +168,390 @@ describe("Orchestrator Integration - Allo Events Processing", () => {
             {
                 ...poolCreatedEvent,
                 rawEvent: poolCreatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process PoolFunded event and apply IncrementRoundFundedAmount changeset", async () => {
+        // Create test event
+        const poolFundedEvent = createTestAlloEvent<"PoolFunded">({
+            contractName: "Allo",
+            eventName: "PoolFunded",
+            params: {
+                poolId: "13",
+                amount: "1000000000000000000", // 1 ETH
+                fee: "10000000000000000", // 0.01 ETH
+            },
+        });
+
+        const { indexerClient } = mocks;
+        const { roundRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        // Mock the round data
+        vi.spyOn(roundRepository, "getRoundByIdOrThrow").mockResolvedValue({
+            id: "13",
+            chainId: chainId,
+            matchTokenAddress: zeroAddress, // ETH
+        } as unknown as Round);
+
+        // Mock indexer to return our event
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([poolFundedEvent])
+            .mockResolvedValue([]);
+
+        // Run orchestrator
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(roundRepository.incrementRoundFunds).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                roundId: "13",
+            },
+            BigInt("1000000000000000000"),
+            "1",
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...poolFundedEvent,
+                rawEvent: poolFundedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process PoolMetadataUpdated event and apply UpdateRound changeset", async () => {
+        const poolMetadataUpdatedEvent = createTestAlloEvent<"PoolMetadataUpdated">({
+            contractName: "Allo",
+            eventName: "PoolMetadataUpdated",
+            params: {
+                poolId: "13",
+                metadata: ["1", "bafkreiadxn64e7ibijctm67flwgbjpsy36avvfsrmzyvraffnwsg75yki4"],
+            },
+        }) as ProcessorEvent<"Allo", "PoolMetadataUpdated">;
+
+        const { indexerClient } = mocks;
+        const { roundRepository, metadataProvider } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(roundRepository, "getRoundByIdOrThrow").mockResolvedValue({
+            id: "13",
+            chainId: chainId,
+            matchTokenAddress: zeroAddress,
+            matchAmount: 0n,
+            matchAmountInUsd: "0",
+        } as unknown as Round);
+        const updatedMetadata = {
+            round: {
+                name: "QuantumStake: Revolutionizing Staking in the Crypto space | Ethereum",
+                roundType: "public",
+                quadraticFundingConfig: {
+                    matchingFundsAvailable: 209500,
+                },
+            },
+            application: {
+                version: "2.0.0",
+                lastUpdatedOn: 1716414832557,
+            },
+        };
+        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue(updatedMetadata);
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([poolMetadataUpdatedEvent])
+            .mockResolvedValue([]);
+
+        // Run orchestrator
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(roundRepository.updateRound).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                id: poolMetadataUpdatedEvent.params.poolId,
+            },
+            {
+                matchAmount: parseUnits("209500", 18),
+                matchAmountInUsd: "209500",
+                applicationMetadataCid:
+                    "bafkreiadxn64e7ibijctm67flwgbjpsy36avvfsrmzyvraffnwsg75yki4",
+                applicationMetadata: updatedMetadata.application,
+                roundMetadataCid: "bafkreiadxn64e7ibijctm67flwgbjpsy36avvfsrmzyvraffnwsg75yki4",
+                roundMetadata: updatedMetadata.round,
+            },
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...poolMetadataUpdatedEvent,
+                rawEvent: poolMetadataUpdatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleGranted event and apply InsertRoundRole changeset when role matches admin role", async () => {
+        const roleGrantedEvent = createTestAlloEvent<"RoleGranted">({
+            contractName: "Allo",
+            eventName: "RoleGranted",
+            params: {
+                role: "0x000000000000000000000000000000000000000000000000000000000000000d" as Bytes32String,
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Allo", "RoleGranted">;
+
+        const { indexerClient } = mocks;
+        const { roundRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        // Mock finding round by admin role
+        vi.spyOn(roundRepository, "getRoundByRole").mockImplementation(
+            async (chainId, roleType, role) => {
+                if (roleType === "admin" && role === roleGrantedEvent.params.role.toLowerCase()) {
+                    return {
+                        id: "13",
+                        chainId,
+                    } as unknown as Round;
+                }
+                return undefined;
+            },
+        );
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleGrantedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+
+        expect(roundRepository.insertRoundRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                roundId: "13",
+                role: "admin",
+                address: roleGrantedEvent.params.account,
+                createdAtBlock: BigInt(roleGrantedEvent.blockNumber),
+            },
+            {},
+        );
+
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleGrantedEvent,
+                rawEvent: roleGrantedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleGranted event and apply InsertPendingRoundRole changeset when role doesn't match any round", async () => {
+        const roleGrantedEvent = createTestAlloEvent<"RoleGranted">({
+            contractName: "Allo",
+            eventName: "RoleGranted",
+            params: {
+                role: "0x1234567890123456789012345678901234567890123456789012345678901234" as Bytes32String,
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Allo", "RoleGranted">;
+
+        const { indexerClient } = mocks;
+        const { roundRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        // Mock finding no round for the role
+        vi.spyOn(roundRepository, "getRoundByRole").mockResolvedValue(undefined);
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleGrantedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+
+        expect(roundRepository.insertPendingRoundRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                role: roleGrantedEvent.params.role.toLowerCase(),
+                address: roleGrantedEvent.params.account,
+                createdAtBlock: BigInt(roleGrantedEvent.blockNumber),
+            },
+            {},
+        );
+
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleGrantedEvent,
+                rawEvent: roleGrantedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleRevoked event and apply DeleteAllRoundRolesByRoleAndAddress changeset when role matches admin role", async () => {
+        const roleRevokedEvent = createTestAlloEvent<"RoleRevoked">({
+            contractName: "Allo",
+            eventName: "RoleRevoked",
+            params: {
+                role: "0x000000000000000000000000000000000000000000000000000000000000000d" as Bytes32String, // admin role
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Allo", "RoleRevoked">;
+
+        const { indexerClient } = mocks;
+        const { roundRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        // Mock finding round by admin role
+        vi.spyOn(roundRepository, "getRoundByRole").mockImplementation(
+            async (chainId, roleType, role) => {
+                if (roleType === "admin" && role === roleRevokedEvent.params.role.toLowerCase()) {
+                    return {
+                        id: "13",
+                        chainId,
+                    } as unknown as Round;
+                }
+                return undefined;
+            },
+        );
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleRevokedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+
+        expect(roundRepository.deleteManyRoundRolesByRoleAndAddress).toHaveBeenCalledWith(
+            chainId,
+            "13",
+            "admin",
+            roleRevokedEvent.params.account,
+            {},
+        );
+
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleRevokedEvent,
+                rawEvent: roleRevokedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleRevoked event and only log warning when role doesn't match any round", async () => {
+        const roleRevokedEvent = createTestAlloEvent<"RoleRevoked">({
+            contractName: "Allo",
+            eventName: "RoleRevoked",
+            params: {
+                role: "0x1234567890123456789012345678901234567890123456789012345678901234" as Bytes32String, // unknown role
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Allo", "RoleRevoked">;
+
+        const { indexerClient } = mocks;
+        const { roundRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        // Mock finding no round for the role
+        vi.spyOn(roundRepository, "getRoundByRole").mockResolvedValue(undefined);
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleRevokedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything()]),
+        );
+        expect(roundRepository.deleteManyPendingRoundRoles).not.toHaveBeenCalled();
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleRevokedEvent,
+                rawEvent: roleRevokedEvent,
             },
             {},
         );

--- a/packages/data-flow/test/integration/allo.integration.spec.ts
+++ b/packages/data-flow/test/integration/allo.integration.spec.ts
@@ -1,0 +1,171 @@
+import { zeroAddress } from "viem";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
+import { IEventRegistryRepository } from "@grants-stack-indexer/repository";
+import { ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+
+import { CoreDependencies, IStrategyRegistry } from "../../src/internal.js";
+import { Orchestrator } from "../../src/orchestrator.js";
+import { DEFAULT_STRATEGY_MAP } from "./helpers/dependencies.js";
+import { createTestAlloEvent, DEFAULT_TIMESTAMP_MS } from "./helpers/eventFactory.js";
+import { createTestOrchestrator } from "./helpers/setup.js";
+import { waitForProcessing } from "./helpers/testing.js";
+
+describe("Orchestrator Integration - Allo Events Processing", () => {
+    let abortController: AbortController;
+    let runPromise: Promise<void> | undefined;
+    let orchestrator: Orchestrator;
+    let mocks: {
+        dependencies: CoreDependencies;
+        indexerClient: IIndexerClient;
+        registries: {
+            eventsRegistry: IEventRegistryRepository;
+            strategyRegistry: IStrategyRegistry;
+        };
+    };
+    const chainId = 1 as ChainId;
+
+    beforeEach(() => {
+        const res = createTestOrchestrator({
+            chainId,
+            strategiesMap: DEFAULT_STRATEGY_MAP,
+        });
+
+        orchestrator = res.orchestrator;
+        mocks = res.mocks;
+
+        abortController = new AbortController();
+        runPromise = undefined;
+    });
+
+    afterEach(async () => {
+        vi.clearAllMocks();
+
+        abortController.abort();
+
+        await runPromise;
+
+        runPromise = undefined;
+    });
+
+    it("process PoolCreated event and apply InsertRound, InsertRoundRole, DeletePendingRoundRoles changesets", async () => {
+        // Create test event
+        const poolCreatedEvent = createTestAlloEvent<"PoolCreated">({
+            contractName: "Allo",
+            eventName: "PoolCreated",
+            params: {
+                token: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                amount: "0",
+                poolId: "13",
+                metadata: ["1", "bafkreid3tuk3shg2o3pwc7d677xgymyeuyqccma72my5waiavecrvhxd3m"],
+                strategy: "0xF5F6Ca46a9DA3C1089d0F2F029cF14F3F714D483",
+                profileId: "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b",
+            },
+        }) as ProcessorEvent<"Allo", "PoolCreated">;
+
+        const { indexerClient } = mocks;
+        const { roundRepository, metadataProvider, evmProvider } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+        const strategyTiming = BigInt(DEFAULT_TIMESTAMP_MS / 1000);
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([poolCreatedEvent])
+            .mockResolvedValue([]);
+        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue(undefined);
+        vi.spyOn(evmProvider, "readContract").mockResolvedValue(strategyTiming);
+        vi.spyOn(roundRepository, "getPendingRoundRoles").mockImplementation((_, name) => {
+            if (name === "admin") {
+                return Promise.resolve([
+                    {
+                        id: 1,
+                        chainId: 1 as ChainId,
+                        role: "admin",
+                        address: "0x123",
+                        createdAtBlock: 1234567n,
+                    },
+                ]);
+            }
+            return Promise.resolve([]);
+        });
+
+        // Run orchestrator
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+            ]),
+        ); // just checking that it was called with 4 changesets
+
+        expect(roundRepository.insertRound).toHaveBeenCalledWith(
+            {
+                chainId: poolCreatedEvent.chainId,
+                id: poolCreatedEvent.params.poolId,
+                tags: ["allo-v2"],
+                totalDonationsCount: 0,
+                totalAmountDonatedInUsd: "0",
+                uniqueDonorsCount: 0,
+                matchTokenAddress: zeroAddress,
+                matchAmount: 0n,
+                matchAmountInUsd: "0",
+                fundedAmount: 0n,
+                fundedAmountInUsd: "0",
+                applicationMetadataCid: poolCreatedEvent.params.metadata[1],
+                applicationMetadata: {},
+                roundMetadataCid: poolCreatedEvent.params.metadata[1],
+                roundMetadata: null,
+                applicationsStartTime: new Date(Number(strategyTiming) * 1000),
+                applicationsEndTime: new Date(Number(strategyTiming) * 1000),
+                donationsStartTime: null,
+                donationsEndTime: null,
+                managerRole: "0x000000000000000000000000000000000000000000000000000000000000000d",
+                adminRole: "0x9c5c8058ff40e9ac62e1dc94ec9ac5e3e6ba7512881310db09ea2196e5e82f38",
+                strategyAddress: poolCreatedEvent.params.strategy,
+                strategyId: DEFAULT_STRATEGY_MAP.get(chainId)?.get(
+                    poolCreatedEvent.params.strategy,
+                ),
+                strategyName: "allov2.DirectGrantsLiteStrategy",
+                createdByAddress: poolCreatedEvent.transactionFields.from,
+                createdAtBlock: BigInt(poolCreatedEvent.blockNumber),
+                updatedAtBlock: BigInt(poolCreatedEvent.blockNumber),
+                projectId: poolCreatedEvent.params.profileId,
+                totalDistributed: 0n,
+                readyForPayoutTransaction: null,
+                matchingDistribution: null,
+            },
+            {},
+        );
+        expect(roundRepository.insertRoundRole).toHaveBeenCalledWith(
+            {
+                chainId: poolCreatedEvent.chainId,
+                roundId: poolCreatedEvent.params.poolId,
+                address: "0x123",
+                role: "admin",
+                createdAtBlock: 1234567n,
+            },
+            {},
+        );
+        expect(roundRepository.deleteManyPendingRoundRoles).toHaveBeenCalledWith([1], {});
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            1 as ChainId,
+            {
+                ...poolCreatedEvent,
+                rawEvent: poolCreatedEvent,
+            },
+            {},
+        );
+    });
+});

--- a/packages/data-flow/test/integration/helpers/dependencies.ts
+++ b/packages/data-flow/test/integration/helpers/dependencies.ts
@@ -1,0 +1,149 @@
+import { Address, Hex } from "viem";
+import { vi } from "vitest";
+
+import type { IIndexerClient } from "@grants-stack-indexer/indexer-client";
+import type {
+    IEventRegistryRepository,
+    TransactionConnection,
+} from "@grants-stack-indexer/repository";
+import { EvmProvider } from "@grants-stack-indexer/chain-providers";
+import { DummyPricingProvider } from "@grants-stack-indexer/pricing";
+import { ChainId } from "@grants-stack-indexer/shared";
+
+import { CoreDependencies, IStrategyRegistry } from "../../../src/internal.js";
+
+// Mock repositories with Vi spies
+export const createMockRepositories = (): Pick<
+    CoreDependencies,
+    | "projectRepository"
+    | "roundRepository"
+    | "applicationRepository"
+    | "donationRepository"
+    | "applicationPayoutRepository"
+    | "transactionManager"
+> => ({
+    projectRepository: {
+        getProjects: vi.fn(),
+        insertProject: vi.fn(),
+        updateProject: vi.fn(),
+        insertProjectRole: vi.fn(),
+        deleteManyProjectRoles: vi.fn(),
+        insertPendingProjectRole: vi.fn(),
+        deleteManyPendingProjectRoles: vi.fn(),
+        getProjectById: vi.fn(),
+        getProjectByIdOrThrow: vi.fn(),
+        getPendingProjectRoles: vi.fn(),
+        getPendingProjectRolesByRole: vi.fn(),
+        getProjectByAnchor: vi.fn(),
+        getProjectByAnchorOrThrow: vi.fn(),
+    },
+    roundRepository: {
+        getRounds: vi.fn(),
+        getRoundById: vi.fn(),
+        insertRound: vi.fn(),
+        updateRound: vi.fn(),
+        incrementRoundFunds: vi.fn(),
+        incrementRoundTotalDistributed: vi.fn(),
+        insertRoundRole: vi.fn(),
+        deleteManyRoundRolesByRoleAndAddress: vi.fn(),
+        insertPendingRoundRole: vi.fn(),
+        deleteManyPendingRoundRoles: vi.fn(),
+        getRoundByIdOrThrow: vi.fn(),
+        getRoundByStrategyAddress: vi.fn(),
+        getRoundByStrategyAddressOrThrow: vi.fn(),
+        getRoundByRole: vi.fn(),
+        getRoundMatchTokenAddressById: vi.fn(),
+        getRoundRoles: vi.fn(),
+        getPendingRoundRoles: vi.fn(),
+    },
+    applicationRepository: {
+        insertApplication: vi.fn(),
+        updateApplication: vi.fn(),
+        getApplicationById: vi.fn(),
+        getApplicationByProjectId: vi.fn(),
+        getApplicationByAnchorAddress: vi.fn(),
+        getApplicationByAnchorAddressOrThrow: vi.fn(),
+        getApplicationsByRoundId: vi.fn(),
+    },
+    donationRepository: {
+        insertDonation: vi.fn(),
+        insertManyDonations: vi.fn(),
+    },
+    applicationPayoutRepository: {
+        insertApplicationPayout: vi.fn(),
+    },
+    transactionManager: {
+        runInTransaction: vi
+            .fn()
+            .mockImplementation((fn: (tx: TransactionConnection) => Promise<unknown>) => {
+                return fn({} as TransactionConnection);
+            }),
+    },
+});
+
+// Mock providers
+export const createMockProviders = (): Pick<
+    CoreDependencies,
+    "pricingProvider" | "metadataProvider" | "evmProvider"
+> => ({
+    pricingProvider: new DummyPricingProvider(),
+    metadataProvider: {
+        getMetadata: vi.fn(),
+    },
+    evmProvider: {
+        getMulticall3Address: vi.fn().mockReturnValue(undefined),
+        getTransaction: vi.fn(),
+        getBalance: vi.fn(),
+        readContract: vi.fn(),
+        multicall: vi.fn(),
+    } as unknown as EvmProvider,
+});
+
+export const createMockIndexerClient = (): IIndexerClient => ({
+    getEventsAfterBlockNumberAndLogIndex: vi.fn(),
+    getEvents: vi.fn(),
+});
+
+export const DEFAULT_STRATEGY_MAP = new Map<ChainId, Map<Address, Hex>>([
+    [
+        1 as ChainId,
+        new Map([
+            [
+                "0xF5F6Ca46a9DA3C1089d0F2F029cF14F3F714D483",
+                "0x103732a8e473467a510d4128ee11065262bdd978f0d9dad89ba68f2c56127e27",
+            ],
+        ]),
+    ],
+]);
+
+export const createMockRegistries = (
+    strategiesMap: Map<ChainId, Map<Address, Hex>>,
+): {
+    eventsRegistry: IEventRegistryRepository;
+    strategyRegistry: IStrategyRegistry;
+} => ({
+    eventsRegistry: {
+        saveLastProcessedEvent: vi.fn(),
+        getLastProcessedEvent: vi.fn(),
+    },
+    strategyRegistry: {
+        getStrategyId: vi.fn().mockImplementation((chainId: ChainId, strategyAddress: Address) => {
+            const chainIdMap = strategiesMap.get(chainId);
+            if (!chainIdMap) {
+                return undefined;
+            }
+            const strategyId = chainIdMap.get(strategyAddress);
+            if (!strategyId) {
+                return undefined;
+            }
+            return {
+                id: strategyId,
+                address: strategyAddress,
+                chainId: chainId,
+                handled: true,
+            };
+        }),
+        saveStrategyId: vi.fn(),
+        getStrategies: vi.fn(),
+    },
+});

--- a/packages/data-flow/test/integration/helpers/dependencies.ts
+++ b/packages/data-flow/test/integration/helpers/dependencies.ts
@@ -102,6 +102,7 @@ export const createMockProviders = (): Pick<
 export const createMockIndexerClient = (): IIndexerClient => ({
     getEventsAfterBlockNumberAndLogIndex: vi.fn(),
     getEvents: vi.fn(),
+    getBlockRangeTimestampByChainId: vi.fn(),
 });
 
 export const DEFAULT_STRATEGY_MAP = new Map<ChainId, Map<Address, Hex>>([

--- a/packages/data-flow/test/integration/helpers/eventFactory.ts
+++ b/packages/data-flow/test/integration/helpers/eventFactory.ts
@@ -1,0 +1,135 @@
+import type {
+    Address,
+    AlloEvent,
+    EventParams,
+    ProcessorEvent,
+    RegistryEvent,
+    StrategyEvent,
+    TimestampMs,
+} from "@grants-stack-indexer/shared";
+
+export const DEFAULT_SRC_ADDRESS = "0x3075bE2EdD29E1b1886c332193239ae321f434Bf" as const;
+export const DEFAULT_FROM_ADDRESS = "0x9511f02B36e6712971c77A91943D4ca7604C6e10" as const;
+export const DEFAULT_TX_HASH =
+    "0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162" as const;
+export const DEFAULT_TIMESTAMP_MS = 1701472394000 as TimestampMs;
+export const DEFAULT_BLOCK_NUMBER = 170147 as const;
+
+export const createTestAlloEvent = <E extends AlloEvent>({
+    contractName,
+    eventName,
+    params,
+    blockNumber = DEFAULT_BLOCK_NUMBER,
+    blockTimestamp = DEFAULT_TIMESTAMP_MS,
+    srcAddress = DEFAULT_SRC_ADDRESS,
+    logIndex = 0,
+    chainId = 1,
+    from = DEFAULT_FROM_ADDRESS,
+    txIndex = 0,
+}: {
+    contractName: "Allo";
+    eventName: E;
+    params: EventParams<"Allo", E>;
+    blockNumber?: number;
+    blockTimestamp?: TimestampMs;
+    srcAddress?: Address;
+    logIndex?: number;
+    chainId?: number;
+    from?: Address;
+    txIndex?: number;
+}): ProcessorEvent<"Allo", AlloEvent> => {
+    return {
+        contractName,
+        eventName,
+        params,
+        blockNumber,
+        blockTimestamp,
+        logIndex,
+        chainId,
+        srcAddress,
+        transactionFields: {
+            hash: DEFAULT_TX_HASH,
+            transactionIndex: txIndex,
+            from,
+        },
+    };
+};
+
+export const createTestRegistryEvent = <E extends RegistryEvent>({
+    eventName,
+    params,
+    blockNumber,
+    blockTimestamp = DEFAULT_TIMESTAMP_MS,
+    logIndex = 0,
+    chainId = 1,
+    srcAddress = DEFAULT_SRC_ADDRESS,
+    from = DEFAULT_FROM_ADDRESS,
+    txIndex = 0,
+}: {
+    eventName: E;
+    params: EventParams<"Registry", E>;
+    blockNumber: number;
+    blockTimestamp?: TimestampMs;
+    logIndex?: number;
+    chainId?: number;
+    srcAddress?: Address;
+    from?: Address;
+    txIndex?: number;
+}): ProcessorEvent<"Registry", RegistryEvent> => {
+    return {
+        contractName: "Registry",
+        eventName,
+        params,
+        blockNumber,
+        blockTimestamp,
+        logIndex,
+        chainId,
+        srcAddress,
+        transactionFields: {
+            hash: DEFAULT_TX_HASH,
+            transactionIndex: txIndex,
+            from,
+        },
+    };
+};
+
+export const createTestStrategyEvent = <E extends StrategyEvent>({
+    eventName,
+    params,
+    blockNumber,
+    strategyId,
+    blockTimestamp = DEFAULT_TIMESTAMP_MS,
+    logIndex = 0,
+    chainId = 1,
+    srcAddress = DEFAULT_SRC_ADDRESS,
+    from = DEFAULT_FROM_ADDRESS,
+    txIndex = 0,
+}: {
+    eventName: E;
+    params: EventParams<"Strategy", E>;
+    blockNumber: number;
+    strategyId: Address;
+    blockTimestamp?: TimestampMs;
+    logIndex?: number;
+    chainId?: number;
+    srcAddress?: Address;
+    from?: Address;
+    txIndex?: number;
+}): ProcessorEvent<"Strategy", E> => {
+    return {
+        contractName: "Strategy",
+        eventName,
+        params,
+        strategyId,
+        blockNumber,
+        blockTimestamp,
+        logIndex,
+        chainId,
+        srcAddress,
+        transactionFields: {
+            hash: DEFAULT_TX_HASH,
+            transactionIndex: txIndex,
+            from,
+        },
+    };
+};

--- a/packages/data-flow/test/integration/helpers/eventFactory.ts
+++ b/packages/data-flow/test/integration/helpers/eventFactory.ts
@@ -2,7 +2,7 @@ import type {
     Address,
     AlloEvent,
     EventParams,
-    ProcessorEvent,
+    IndexerFetchedEvent,
     RegistryEvent,
     StrategyEvent,
     TimestampMs,
@@ -37,7 +37,7 @@ export const createTestAlloEvent = <E extends AlloEvent>({
     chainId?: number;
     from?: Address;
     txIndex?: number;
-}): ProcessorEvent<"Allo", AlloEvent> => {
+}): IndexerFetchedEvent<"Allo", E> => {
     return {
         contractName,
         eventName,
@@ -75,7 +75,7 @@ export const createTestRegistryEvent = <E extends RegistryEvent>({
     srcAddress?: Address;
     from?: Address;
     txIndex?: number;
-}): ProcessorEvent<"Registry", RegistryEvent> => {
+}): IndexerFetchedEvent<"Registry", E> => {
     return {
         contractName: "Registry",
         eventName,
@@ -97,7 +97,6 @@ export const createTestStrategyEvent = <E extends StrategyEvent>({
     eventName,
     params,
     blockNumber,
-    strategyId,
     blockTimestamp = DEFAULT_TIMESTAMP_MS,
     logIndex = 0,
     chainId = 1,
@@ -108,19 +107,17 @@ export const createTestStrategyEvent = <E extends StrategyEvent>({
     eventName: E;
     params: EventParams<"Strategy", E>;
     blockNumber: number;
-    strategyId: Address;
     blockTimestamp?: TimestampMs;
     logIndex?: number;
     chainId?: number;
     srcAddress?: Address;
     from?: Address;
     txIndex?: number;
-}): ProcessorEvent<"Strategy", E> => {
+}): IndexerFetchedEvent<"Strategy", E> => {
     return {
         contractName: "Strategy",
         eventName,
         params,
-        strategyId,
         blockNumber,
         blockTimestamp,
         logIndex,

--- a/packages/data-flow/test/integration/helpers/eventFactory.ts
+++ b/packages/data-flow/test/integration/helpers/eventFactory.ts
@@ -58,7 +58,7 @@ export const createTestAlloEvent = <E extends AlloEvent>({
 export const createTestRegistryEvent = <E extends RegistryEvent>({
     eventName,
     params,
-    blockNumber,
+    blockNumber = DEFAULT_BLOCK_NUMBER,
     blockTimestamp = DEFAULT_TIMESTAMP_MS,
     logIndex = 0,
     chainId = 1,
@@ -68,7 +68,7 @@ export const createTestRegistryEvent = <E extends RegistryEvent>({
 }: {
     eventName: E;
     params: EventParams<"Registry", E>;
-    blockNumber: number;
+    blockNumber?: number;
     blockTimestamp?: TimestampMs;
     logIndex?: number;
     chainId?: number;

--- a/packages/data-flow/test/integration/helpers/setup.ts
+++ b/packages/data-flow/test/integration/helpers/setup.ts
@@ -1,0 +1,82 @@
+import { vi } from "vitest";
+
+import type { Address, ChainId, Hex, ILogger } from "@grants-stack-indexer/shared";
+import { type IIndexerClient } from "@grants-stack-indexer/indexer-client";
+import { IEventRegistryRepository } from "@grants-stack-indexer/repository";
+import { ExponentialBackoff } from "@grants-stack-indexer/shared";
+
+import { CoreDependencies, IStrategyRegistry } from "../../../src/internal.js";
+import { Orchestrator } from "../../../src/orchestrator.js";
+import {
+    createMockIndexerClient,
+    createMockProviders,
+    createMockRegistries,
+    createMockRepositories,
+    DEFAULT_STRATEGY_MAP,
+} from "./dependencies.js";
+
+export const createTestOrchestrator = (
+    config: {
+        chainId: ChainId;
+        strategiesMap: Map<ChainId, Map<Address, Hex>>;
+    } = { chainId: 1 as ChainId, strategiesMap: DEFAULT_STRATEGY_MAP },
+): {
+    orchestrator: Orchestrator;
+    mocks: {
+        dependencies: CoreDependencies;
+        indexerClient: IIndexerClient;
+        registries: {
+            eventsRegistry: IEventRegistryRepository;
+            strategyRegistry: IStrategyRegistry;
+        };
+        logger: ILogger;
+    };
+} => {
+    const repositories = createMockRepositories();
+    const providers = createMockProviders();
+    const mockNotifier = {
+        send: vi.fn(),
+    };
+    const mockLogger = {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+    };
+    const mockIndexerClient = createMockIndexerClient();
+    const { eventsRegistry, strategyRegistry } = createMockRegistries(config.strategiesMap);
+
+    const dependencies: CoreDependencies = {
+        ...repositories,
+        ...providers,
+    };
+
+    const orchestrator = new Orchestrator(
+        config.chainId,
+        dependencies,
+        mockIndexerClient,
+        {
+            eventsRegistry,
+            strategyRegistry,
+        },
+        1000,
+        0, // No delay in tests
+        new ExponentialBackoff({ baseDelay: 10, factor: 2, maxAttempts: 1 }),
+        mockLogger,
+        mockNotifier,
+    );
+
+    return {
+        orchestrator,
+        mocks: {
+            dependencies,
+            logger: mockLogger,
+            indexerClient: mockIndexerClient,
+            registries: {
+                eventsRegistry,
+                strategyRegistry,
+            },
+        },
+    };
+};

--- a/packages/data-flow/test/integration/helpers/testing.ts
+++ b/packages/data-flow/test/integration/helpers/testing.ts
@@ -1,0 +1,17 @@
+import { MockInstance, vi } from "vitest";
+
+export const waitForProcessing = async (
+    eventsFetcherSpy: MockInstance,
+    dataLoaderSpy: MockInstance,
+): Promise<void> => {
+    await vi.waitFor(
+        () => {
+            if (eventsFetcherSpy.mock.calls.length < 2) throw new Error("Not yet called");
+            if (dataLoaderSpy.mock.calls.length < 1) throw new Error("Not yet called");
+        },
+        {
+            timeout: 500,
+            interval: 50,
+        },
+    );
+};

--- a/packages/data-flow/test/integration/registry.integration.spec.ts
+++ b/packages/data-flow/test/integration/registry.integration.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
 import { IEventRegistryRepository, Project } from "@grants-stack-indexer/repository";
-import { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+import { Bytes32String, ChainId } from "@grants-stack-indexer/shared";
 
 import { CoreDependencies, IStrategyRegistry } from "../../src/internal.js";
 import { Orchestrator } from "../../src/orchestrator.js";
@@ -58,7 +58,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                 owner: DEFAULT_FROM_ADDRESS,
                 anchor: mockAnchorAddress,
             },
-        }) as ProcessorEvent<"Registry", "ProfileCreated">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository, metadataProvider } = mocks.dependencies;
@@ -161,7 +161,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                     "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
                 metadata: ["1", "ipfs://updated-metadata"],
             },
-        }) as ProcessorEvent<"Registry", "ProfileMetadataUpdated">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository, metadataProvider } = mocks.dependencies;
@@ -223,7 +223,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                     "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
                 metadata: ["1", "ipfs://invalid-metadata"],
             },
-        }) as ProcessorEvent<"Registry", "ProfileMetadataUpdated">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository, metadataProvider } = mocks.dependencies;
@@ -282,7 +282,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                 name: "Updated Project Name",
                 anchor: mockAnchorAddress,
             },
-        }) as ProcessorEvent<"Registry", "ProfileNameUpdated">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository } = mocks.dependencies;
@@ -336,7 +336,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                     "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
                 owner: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Registry", "ProfileOwnerUpdated">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository } = mocks.dependencies;
@@ -397,7 +397,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Registry", "RoleGranted">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository } = mocks.dependencies;
@@ -458,7 +458,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Registry", "RoleGranted">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository } = mocks.dependencies;
@@ -511,7 +511,7 @@ describe("Orchestrator Integration - Registry Events Processing", () => {
                 account: DEFAULT_FROM_ADDRESS,
                 sender: DEFAULT_FROM_ADDRESS,
             },
-        }) as ProcessorEvent<"Registry", "RoleRevoked">;
+        });
 
         const { indexerClient } = mocks;
         const { projectRepository } = mocks.dependencies;

--- a/packages/data-flow/test/integration/registry.integration.spec.ts
+++ b/packages/data-flow/test/integration/registry.integration.spec.ts
@@ -1,0 +1,559 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IIndexerClient } from "@grants-stack-indexer/indexer-client";
+import { IEventRegistryRepository, Project } from "@grants-stack-indexer/repository";
+import { Bytes32String, ChainId, ProcessorEvent } from "@grants-stack-indexer/shared";
+
+import { CoreDependencies, IStrategyRegistry } from "../../src/internal.js";
+import { Orchestrator } from "../../src/orchestrator.js";
+import { DEFAULT_STRATEGY_MAP } from "./helpers/dependencies.js";
+import { createTestRegistryEvent, DEFAULT_FROM_ADDRESS } from "./helpers/eventFactory.js";
+import { createTestOrchestrator } from "./helpers/setup.js";
+import { waitForProcessing } from "./helpers/testing.js";
+
+describe("Orchestrator Integration - Registry Events Processing", () => {
+    let abortController: AbortController;
+    let runPromise: Promise<void> | undefined;
+    let orchestrator: Orchestrator;
+    let mocks: {
+        dependencies: CoreDependencies;
+        indexerClient: IIndexerClient;
+        registries: {
+            eventsRegistry: IEventRegistryRepository;
+            strategyRegistry: IStrategyRegistry;
+        };
+    };
+    const chainId = 1 as ChainId;
+    const mockAnchorAddress = DEFAULT_FROM_ADDRESS;
+
+    beforeEach(() => {
+        const res = createTestOrchestrator({
+            chainId,
+            strategiesMap: DEFAULT_STRATEGY_MAP,
+        });
+
+        orchestrator = res.orchestrator;
+        mocks = res.mocks;
+
+        abortController = new AbortController();
+        runPromise = undefined;
+    });
+
+    afterEach(async () => {
+        vi.clearAllMocks();
+        abortController.abort();
+        await runPromise;
+        runPromise = undefined;
+    });
+
+    it("process ProfileCreated event and apply InsertProject and InsertProjectRole changesets", async () => {
+        const profileCreatedEvent = createTestRegistryEvent<"ProfileCreated">({
+            eventName: "ProfileCreated",
+            params: {
+                profileId:
+                    "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                nonce: "1",
+                name: "Test Project",
+                metadata: ["1", "bafkreid3tuk3shg2o3pwc7d677xgymyeuyqccma72my5waiavecrvhxd3m"],
+                owner: DEFAULT_FROM_ADDRESS,
+                anchor: mockAnchorAddress,
+            },
+        }) as ProcessorEvent<"Registry", "ProfileCreated">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository, metadataProvider } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue({});
+        vi.spyOn(projectRepository, "getPendingProjectRolesByRole").mockResolvedValue([
+            {
+                id: 1,
+                chainId,
+                role: profileCreatedEvent.params.profileId,
+                address: DEFAULT_FROM_ADDRESS,
+                createdAtBlock: BigInt(1234567),
+            },
+        ]);
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([profileCreatedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        // Verify changesets
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+            ]),
+        );
+
+        expect(projectRepository.insertProject).toHaveBeenCalledWith(
+            {
+                tags: ["allo-v2"],
+                chainId: chainId,
+                registryAddress: profileCreatedEvent.srcAddress,
+                id: profileCreatedEvent.params.profileId,
+                name: profileCreatedEvent.params.name,
+                nonce: BigInt(profileCreatedEvent.params.nonce),
+                anchorAddress: profileCreatedEvent.params.anchor,
+                projectNumber: null,
+                metadataCid: profileCreatedEvent.params.metadata[1],
+                metadata: null,
+                createdByAddress: profileCreatedEvent.transactionFields.from,
+                createdAtBlock: BigInt(profileCreatedEvent.blockNumber),
+                updatedAtBlock: BigInt(profileCreatedEvent.blockNumber),
+                projectType: "canonical",
+            },
+            {},
+        );
+        expect(projectRepository.insertProjectRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                projectId: profileCreatedEvent.params.profileId,
+                address: profileCreatedEvent.params.owner,
+                role: "owner",
+                createdAtBlock: BigInt(profileCreatedEvent.blockNumber),
+            },
+            {},
+        );
+        expect(projectRepository.insertProjectRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                projectId: profileCreatedEvent.params.profileId,
+                address: DEFAULT_FROM_ADDRESS,
+                role: "member",
+                createdAtBlock: BigInt(profileCreatedEvent.blockNumber),
+            },
+            {},
+        );
+        expect(projectRepository.deleteManyPendingProjectRoles).toHaveBeenCalledWith([1], {});
+
+        // Verify event was marked as processed
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...profileCreatedEvent,
+                rawEvent: profileCreatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process ProfileMetadataUpdated event and apply UpdateProject changeset with valid metadata", async () => {
+        const profileMetadataUpdatedEvent = createTestRegistryEvent<"ProfileMetadataUpdated">({
+            eventName: "ProfileMetadataUpdated",
+            params: {
+                profileId:
+                    "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                metadata: ["1", "ipfs://updated-metadata"],
+            },
+        }) as ProcessorEvent<"Registry", "ProfileMetadataUpdated">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository, metadataProvider } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        const updatedMetadata = {
+            name: "Updated Project",
+            description: "Updated Description",
+            type: "project",
+        };
+
+        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue(updatedMetadata);
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([profileMetadataUpdatedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(projectRepository.updateProject).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                id: profileMetadataUpdatedEvent.params.profileId,
+            },
+            {
+                metadataCid: "ipfs://updated-metadata",
+                metadata: updatedMetadata,
+                projectType: "canonical",
+            },
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...profileMetadataUpdatedEvent,
+                rawEvent: profileMetadataUpdatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process ProfileMetadataUpdated event and apply UpdateProject changeset with invalid metadata", async () => {
+        const profileMetadataUpdatedEvent = createTestRegistryEvent<"ProfileMetadataUpdated">({
+            eventName: "ProfileMetadataUpdated",
+            params: {
+                profileId:
+                    "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                metadata: ["1", "ipfs://invalid-metadata"],
+            },
+        }) as ProcessorEvent<"Registry", "ProfileMetadataUpdated">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository, metadataProvider } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(metadataProvider, "getMetadata").mockResolvedValue({
+            invalid: "metadata",
+        });
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([profileMetadataUpdatedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(projectRepository.updateProject).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                id: profileMetadataUpdatedEvent.params.profileId,
+            },
+            {
+                metadataCid: "ipfs://invalid-metadata",
+                metadata: null,
+                projectType: "canonical",
+            },
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...profileMetadataUpdatedEvent,
+                rawEvent: profileMetadataUpdatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process ProfileNameUpdated event and apply UpdateProject changeset", async () => {
+        const profileNameUpdatedEvent = createTestRegistryEvent<"ProfileNameUpdated">({
+            eventName: "ProfileNameUpdated",
+            params: {
+                profileId:
+                    "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                name: "Updated Project Name",
+                anchor: mockAnchorAddress,
+            },
+        }) as ProcessorEvent<"Registry", "ProfileNameUpdated">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([profileNameUpdatedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(projectRepository.updateProject).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                id: profileNameUpdatedEvent.params.profileId,
+            },
+            {
+                name: profileNameUpdatedEvent.params.name,
+                anchorAddress: profileNameUpdatedEvent.params.anchor,
+            },
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...profileNameUpdatedEvent,
+                rawEvent: profileNameUpdatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process ProfileOwnerUpdated event and apply DeleteAllProjectRolesByRole and InsertProjectRole changesets", async () => {
+        const profileOwnerUpdatedEvent = createTestRegistryEvent<"ProfileOwnerUpdated">({
+            eventName: "ProfileOwnerUpdated",
+            params: {
+                profileId:
+                    "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                owner: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Registry", "ProfileOwnerUpdated">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([profileOwnerUpdatedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything(), expect.anything()]),
+        );
+
+        expect(projectRepository.deleteManyProjectRoles).toHaveBeenCalledWith(
+            chainId,
+            profileOwnerUpdatedEvent.params.profileId,
+            "owner",
+            undefined,
+            {},
+        );
+        expect(projectRepository.insertProjectRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                projectId: profileOwnerUpdatedEvent.params.profileId,
+                address: profileOwnerUpdatedEvent.params.owner,
+                role: "owner",
+                createdAtBlock: BigInt(profileOwnerUpdatedEvent.blockNumber),
+            },
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...profileOwnerUpdatedEvent,
+                rawEvent: profileOwnerUpdatedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleGranted event and apply InsertProjectRole changeset when project exists", async () => {
+        const roleGrantedEvent = createTestRegistryEvent<"RoleGranted">({
+            eventName: "RoleGranted",
+            params: {
+                role: "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Registry", "RoleGranted">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        // Mock finding existing project
+        vi.spyOn(projectRepository, "getProjectById").mockResolvedValue({
+            id: roleGrantedEvent.params.role,
+            chainId: chainId,
+        } as unknown as Project);
+
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleGrantedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+
+        expect(projectRepository.insertProjectRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                projectId: roleGrantedEvent.params.role,
+                address: roleGrantedEvent.params.account,
+                role: "member",
+                createdAtBlock: BigInt(roleGrantedEvent.blockNumber),
+            },
+            {},
+        );
+
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleGrantedEvent,
+                rawEvent: roleGrantedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleGranted event and apply InsertPendingProjectRole changeset when project doesn't exist", async () => {
+        const roleGrantedEvent = createTestRegistryEvent<"RoleGranted">({
+            eventName: "RoleGranted",
+            params: {
+                role: "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Registry", "RoleGranted">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(projectRepository, "getProjectById").mockResolvedValue(undefined);
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleGrantedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(projectRepository.insertPendingProjectRole).toHaveBeenCalledWith(
+            {
+                chainId: chainId,
+                role: roleGrantedEvent.params.role.toLowerCase(),
+                address: roleGrantedEvent.params.account,
+                createdAtBlock: BigInt(roleGrantedEvent.blockNumber),
+            },
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleGrantedEvent,
+                rawEvent: roleGrantedEvent,
+            },
+            {},
+        );
+    });
+
+    it("process RoleRevoked event and apply DeleteAllProjectRolesByRoleAndAddress changeset when project exists", async () => {
+        const roleRevokedEvent = createTestRegistryEvent<"RoleRevoked">({
+            eventName: "RoleRevoked",
+            params: {
+                role: "0x384959f32e27e7813e609989ec4636755f933c4bb5b8943cbdb5cf3b8ee7b66b" as Bytes32String,
+                account: DEFAULT_FROM_ADDRESS,
+                sender: DEFAULT_FROM_ADDRESS,
+            },
+        }) as ProcessorEvent<"Registry", "RoleRevoked">;
+
+        const { indexerClient } = mocks;
+        const { projectRepository } = mocks.dependencies;
+        const { eventsRegistry } = mocks.registries;
+
+        const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+        const eventsFetcherSpy = vi.spyOn(
+            orchestrator["eventsFetcher"],
+            "fetchEventsByBlockNumberAndLogIndex",
+        );
+
+        vi.spyOn(projectRepository, "getProjectById").mockResolvedValue({
+            id: roleRevokedEvent.params.role,
+            chainId: chainId,
+        } as unknown as Project);
+        vi.spyOn(indexerClient, "getEventsAfterBlockNumberAndLogIndex")
+            .mockResolvedValueOnce([roleRevokedEvent])
+            .mockResolvedValue([]);
+
+        const orchestratorPromise = orchestrator.run(abortController.signal);
+        await waitForProcessing(eventsFetcherSpy, dataLoaderSpy);
+
+        abortController.abort();
+        await orchestratorPromise;
+
+        expect(orchestrator["dataLoader"].applyChanges).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.anything(), expect.anything()]),
+        );
+        expect(projectRepository.deleteManyProjectRoles).toHaveBeenCalledWith(
+            chainId,
+            roleRevokedEvent.params.role,
+            "member",
+            roleRevokedEvent.params.account,
+            {},
+        );
+        expect(eventsRegistry.saveLastProcessedEvent).toHaveBeenCalledWith(
+            chainId,
+            {
+                ...roleRevokedEvent,
+                rawEvent: roleRevokedEvent,
+            },
+            {},
+        );
+    });
+});

--- a/packages/processors/src/processors/registry/handlers/profileCreated.handler.ts
+++ b/packages/processors/src/processors/registry/handlers/profileCreated.handler.ts
@@ -59,7 +59,7 @@ export class ProfileCreatedHandler implements IEventHandler<"Registry", "Profile
                         registryAddress: getAddress(this.event.srcAddress),
                         id: profileId,
                         name: this.event.params.name,
-                        nonce: this.event.params.nonce,
+                        nonce: BigInt(this.event.params.nonce),
                         anchorAddress: getAddress(this.event.params.anchor),
                         projectNumber: null,
                         metadataCid: metadataCid,

--- a/packages/processors/test/registry/handlers/profileCreated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileCreated.handler.spec.ts
@@ -47,9 +47,9 @@ describe("ProfileCreatedHandler", () => {
             blockNumber: 123,
             params: {
                 profileId: "0x1231231234" as Bytes32String,
-                metadata: [1n, "cid-metadata"],
+                metadata: ["1", "cid-metadata"],
                 name: "Test Project",
-                nonce: 1n,
+                nonce: "1",
                 anchor: mockedAddress,
                 owner: mockedAddress,
             },

--- a/packages/shared/src/types/events/registry.ts
+++ b/packages/shared/src/types/events/registry.ts
@@ -49,15 +49,15 @@ export type RegistryEventParams<T extends RegistryEvent> = T extends "ProfileCre
 // =============================================================================
 export type ProfileCreatedParams = {
     profileId: Bytes32String;
-    nonce: bigint;
+    nonce: string; //uint256
     name: string;
-    metadata: [protocol: bigint, pointer: string];
+    metadata: [protocol: string /*uint256*/, pointer: string];
     owner: Address;
     anchor: Address;
 };
 export type ProfileMetadataUpdatedParams = {
     profileId: Bytes32String;
-    metadata: [protocol: bigint, pointer: string];
+    metadata: [protocol: string /*uint256*/, pointer: string];
 };
 export type ProfileNameUpdatedParams = {
     profileId: Bytes32String;


### PR DESCRIPTION
# 🤖 Linear

Closes GIT-263 GIT-264

## Description
We write integration tests for Allo and Registry events on Orchestrator level. We aim at verifying that Processors and DataLoader communication is working correctly. Although these are integration tests, we mock some components (mainly external ones and Repositories)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the system’s event processing capabilities to improve responsiveness and accuracy in handling various operations.
  
- **Bug Fixes**
  - Standardized event data handling to ensure consistent and reliable updates, leading to improved stability in profile and role management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->