### PR TITLE
fix: use multiformats library and allow paths in cid

### DIFF
--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -31,6 +31,7 @@
         "@grants-stack-indexer/repository": "workspace:*",
         "@grants-stack-indexer/shared": "workspace:*",
         "axios": "1.7.7",
+        "multiformats": "13.3.2",
         "pinata": "1.10.1",
         "ts-retry": "5.0.1",
         "zod": "3.23.8"

--- a/packages/metadata/src/utils/index.ts
+++ b/packages/metadata/src/utils/index.ts
@@ -1,4 +1,23 @@
-export const isValidCid = (cid: string): boolean => {
-    const cidRegex = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[0-9A-Za-z]{50,})$/;
-    return cidRegex.test(cid);
+import { CID } from "multiformats/cid";
+
+export const isValidCid = (input: string): boolean => {
+    try {
+        // Extract CID part from optional paths/params
+        const match = input.match(/^([^/?#]+)(?:[/?#].*)?$/);
+        if (!match) return false;
+
+        const cid = match[1];
+
+        if (!cid) return false;
+
+        // Quick regex check for basic format
+        const cidRegex = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[0-9A-Za-z]+)$/;
+        if (!cidRegex.test(cid)) return false;
+
+        // Full validation using multiformats/cid
+        CID.parse(cid);
+        return true;
+    } catch {
+        return false;
+    }
 };

--- a/packages/metadata/test/utils/index.spec.ts
+++ b/packages/metadata/test/utils/index.spec.ts
@@ -36,4 +36,9 @@ describe("isValidCid", () => {
             expect(isValidCid(input as unknown as string)).toBe(false);
         });
     });
+
+    it("returns true when CID has path or query parameters", () => {
+        const cidWithParams = "QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/path?param=value";
+        expect(isValidCid(cidWithParams)).toBe(true);
+    });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
             axios:
                 specifier: 1.7.7
                 version: 1.7.7
+            multiformats:
+                specifier: 13.3.2
+                version: 13.3.2
             pinata:
                 specifier: 1.10.1
                 version: 1.10.1


### PR DESCRIPTION
# 🤖 Linear

Closes GIT-269

## Description

Fixes IPFS CID validation, by using a more reliable library [multiformats](https://www.npmjs.com/package/multiformats)
Also, allow for having CID with paths and params like: {cid}/pathtofile.json?param=val

## Checklist before requesting a review

-   [ ] I have conducted a self-review of my code.
-   [ ] I have conducted a QA.
-   [ ] If it is a core feature, I have included comprehensive tests.
