### PR TITLE
fix: save processed event for skipped events

### DIFF
--- a/packages/data-flow/src/orchestrator.ts
+++ b/packages/data-flow/src/orchestrator.ts
@@ -176,6 +176,19 @@ export class Orchestrator {
                                     },
                                 },
                             ]);
+                        } else {
+                            await this.dataLoader.applyChanges([
+                                {
+                                    type: "InsertProcessedEvent",
+                                    args: {
+                                        chainId: this.chainId,
+                                        processedEvent: {
+                                            ...event!,
+                                            rawEvent: event,
+                                        },
+                                    },
+                                },
+                            ]);
                         }
                     },
                     { abortSignal: signal },

--- a/packages/data-flow/test/unit/orchestrator.spec.ts
+++ b/packages/data-flow/test/unit/orchestrator.spec.ts
@@ -545,6 +545,9 @@ describe("Orchestrator", { sequential: true }, () => {
             getEventsAfterBlockNumberAndLogIndexSpy
                 .mockResolvedValueOnce([mockEvent])
                 .mockResolvedValue([]);
+            const dataLoaderSpy = vi.spyOn(orchestrator["dataLoader"], "applyChanges");
+
+            vi.spyOn(mockEventsRegistry, "getLastProcessedEvent").mockResolvedValue(undefined);
 
             vi.spyOn(mockStrategyRegistry, "getStrategyId").mockResolvedValue({
                 id: unhandledStrategyId,
@@ -557,12 +560,24 @@ describe("Orchestrator", { sequential: true }, () => {
             runPromise = orchestrator.run(abortController.signal);
 
             await vi.waitFor(() => {
-                if (getEventsAfterBlockNumberAndLogIndexSpy.mock.calls.length >= 2)
+                if (getEventsAfterBlockNumberAndLogIndexSpy.mock.calls.length < 1)
                     throw new Error("Not yet called");
             });
 
             expect(orchestrator["eventsProcessor"].processEvent).not.toHaveBeenCalled();
-            expect(orchestrator["dataLoader"].applyChanges).not.toHaveBeenCalled();
+            expect(dataLoaderSpy).toHaveBeenCalledWith([
+                {
+                    type: "InsertProcessedEvent",
+                    args: {
+                        chainId,
+                        processedEvent: {
+                            ...mockEvent,
+                            rawEvent: mockEvent,
+                            strategyId: unhandledStrategyId,
+                        },
+                    },
+                },
+            ]);
             expect(mockEventsRegistry.saveLastProcessedEvent).not.toHaveBeenCalled();
             expect(mockStrategyRegistry.saveStrategyId).not.toHaveBeenCalled();
         });


### PR DESCRIPTION
# 🤖 Linear

Closes GIT-270

## Description
Fix issue that skipped events (from not handleable strategies) weren't checkpointed to the events registry.

## Checklist before requesting a review

-   [x] I have conducted a self-review of my code.
-   [x] I have conducted a QA.
-   [x] If it is a core feature, I have included comprehensive tests.
