### PR TITLE
feat: scripts for creating blue-green dbs and copying cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "clean": "turbo run clean",
         "db:cache:migrate": "pnpm run --filter @grants-stack-indexer/migrations db:cache:migrate",
         "db:cache:reset": "pnpm run --filter @grants-stack-indexer/migrations db:cache:reset",
+        "db:copy-cache": "pnpm run --filter @grants-stack-indexer/migrations db:copy-cache",
+        "db:create-databases": "pnpm run --filter @grants-stack-indexer/migrations db:create-databases",
         "db:migrate": "pnpm run --filter @grants-stack-indexer/migrations db:migrate",
         "db:reset": "pnpm run --filter @grants-stack-indexer/migrations db:reset",
         "dev": "turbo run dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
             kysely:
                 specifier: 0.27.4
                 version: 0.27.4
+            pg:
+                specifier: 8.13.0
+                version: 8.13.0
             yargs:
                 specifier: 17.7.2
                 version: 17.7.2
@@ -378,6 +381,9 @@ importers:
                 specifier: 3.23.8
                 version: 3.23.8
         devDependencies:
+            "@types/pg":
+                specifier: 8.11.10
+                version: 8.11.10
             "@types/yargs":
                 specifier: 17.0.33
                 version: 17.0.33

--- a/scripts/hasura-config/src/services/hasura.api.ts
+++ b/scripts/hasura-config/src/services/hasura.api.ts
@@ -142,7 +142,7 @@ export class HasuraMetadataApi<Tables extends readonly string[]> {
 
             // Object relationship: in the child table
             const objectRelationshipPayload = {
-                name: singularize(camelize(parentTable.name)), // name derived from parent table
+                name: singularize(camelize(parentTable.name, true)), // name derived from parent table
                 table: childTable,
                 source: "default",
                 using: {
@@ -160,7 +160,7 @@ export class HasuraMetadataApi<Tables extends readonly string[]> {
             );
 
             const arrayRelationshipPayload = {
-                name: camelize(childTable.name), // name derived from child table
+                name: camelize(childTable.name, true), // name derived from child table
                 table: parentTable,
                 source: "default",
                 using: {

--- a/scripts/migrations/README-DB-BLUE-GREEN.md
+++ b/scripts/migrations/README-DB-BLUE-GREEN.md
@@ -7,7 +7,7 @@ This utility provides scripts for managing PostgreSQL databases in a blue-green 
 The scripts offer two main operations:
 
 1. **Database Creation** - Create both blue and green databases if they don't exist
-2. **Cache Data Copy** - Copy external services cache data from one database to the other
+2. **Database Copy** - Create an exact copy of all tables and data from one database to the other
 
 ## Database Creation
 
@@ -25,35 +25,48 @@ pnpm db:create-databases
 3. If either database doesn't exist, it creates it
 4. This operation can be run multiple times without error, as it only creates databases when needed
 
-## Cache Data Copy
+## Database Copy
 
-Use this operation to copy cache data between blue and green databases. This is essential for maintaining cache consistency during blue-green deployments.
+Use this operation to create an exact copy of one database to the other. This is essential for maintaining consistency during blue-green deployments.
 
 ```bash
-# Copy cache data from blue to green
+# Copy all tables and data from blue to green
 pnpm db:copy-cache --copyFrom=blue
 
-# Copy cache data from green to blue
+# Copy all tables and data from green to blue
 pnpm db:copy-cache --copyFrom=green
 
 # Using the shorthand parameter
 pnpm db:copy-cache -f blue
 ```
 
-### How Cache Data Copy Works
+### How Database Copy Works
 
 1. The script reads the PostgreSQL connection details from the `DATABASE_URL` environment variable
-2. It handles the two specific cache tables: `price_cache` and `metadata_cache`
-3. For each table:
-    - It truncates the target table
-    - Copies all data from the source to the target table
+2. It determines the source and target databases based on the `copyFrom` parameter
+3. It retrieves a list of all tables in the source database
+4. For each table:
+    - It truncates the target table (removing all existing data)
+    - Copies all data from the source table to the target table
     - Processes data in batches to avoid memory issues with large tables
+5. After completion, the target database is an exact copy of the source database
 
-### Cache Tables
+## Blue-Green Deployment Process
 
-The script only copies the following tables, which contain cached data from external services:
+Here's a typical workflow for using this utility in a blue-green deployment:
 
--   `price_cache`: Stores token price information
--   `metadata_cache`: Stores token metadata
+```bash
+# Step 1: Ensure both databases exist
+pnpm db:create-databases
 
-All other tables are managed through the regular migration process and are not part of the blue-green deployment cache copying strategy.
+# Step 2: Deploy new version to the inactive environment (e.g., green)
+# (Your deployment steps here)
+
+# Step 3: Copy data from the active environment to the inactive one
+pnpm db:copy-cache --copyFrom=blue
+
+# Step 4: Switch traffic to the newly updated environment
+# (Your traffic switching steps here)
+```
+
+This process allows for zero-downtime deployments by maintaining two parallel database environments.

--- a/scripts/migrations/README-DB-BLUE-GREEN.md
+++ b/scripts/migrations/README-DB-BLUE-GREEN.md
@@ -1,0 +1,59 @@
+# Blue-Green Database Operations
+
+This utility provides scripts for managing PostgreSQL databases in a blue-green deployment strategy. It handles the creation and maintenance of two fixed databases: **GitcoinDatalayerBlue** and **GitcoinDatalayerGreen**.
+
+## Features
+
+The scripts offer two main operations:
+
+1. **Database Creation** - Create both blue and green databases if they don't exist
+2. **Cache Data Copy** - Copy external services cache data from one database to the other
+
+## Database Creation
+
+Use this operation to create the required blue and green databases if they don't already exist.
+
+```bash
+# Create both databases if they don't exist
+pnpm db:create-databases
+```
+
+### How Database Creation Works
+
+1. The script reads the PostgreSQL connection details from the `DATABASE_URL` environment variable
+2. It checks if the databases `GitcoinDatalayerBlue` and `GitcoinDatalayerGreen` exist
+3. If either database doesn't exist, it creates it
+4. This operation can be run multiple times without error, as it only creates databases when needed
+
+## Cache Data Copy
+
+Use this operation to copy cache data between blue and green databases. This is essential for maintaining cache consistency during blue-green deployments.
+
+```bash
+# Copy cache data from blue to green
+pnpm db:copy-cache --copyFrom=blue
+
+# Copy cache data from green to blue
+pnpm db:copy-cache --copyFrom=green
+
+# Using the shorthand parameter
+pnpm db:copy-cache -f blue
+```
+
+### How Cache Data Copy Works
+
+1. The script reads the PostgreSQL connection details from the `DATABASE_URL` environment variable
+2. It handles the two specific cache tables: `price_cache` and `metadata_cache`
+3. For each table:
+    - It truncates the target table
+    - Copies all data from the source to the target table
+    - Processes data in batches to avoid memory issues with large tables
+
+### Cache Tables
+
+The script only copies the following tables, which contain cached data from external services:
+
+-   `price_cache`: Stores token price information
+-   `metadata_cache`: Stores token metadata
+
+All other tables are managed through the regular migration process and are not part of the blue-green deployment cache copying strategy.

--- a/scripts/migrations/README-DB-BLUE-GREEN.md
+++ b/scripts/migrations/README-DB-BLUE-GREEN.md
@@ -7,7 +7,7 @@ This utility provides scripts for managing PostgreSQL databases in a blue-green 
 The scripts offer two main operations:
 
 1. **Database Creation** - Create both blue and green databases if they don't exist
-2. **Database Copy** - Create an exact copy of all tables and data from one database to the other
+2. **Cache Data Copy** - Copy external services cache data from one database to the other
 
 ## Database Creation
 
@@ -25,48 +25,35 @@ pnpm db:create-databases
 3. If either database doesn't exist, it creates it
 4. This operation can be run multiple times without error, as it only creates databases when needed
 
-## Database Copy
+## Cache Data Copy
 
-Use this operation to create an exact copy of one database to the other. This is essential for maintaining consistency during blue-green deployments.
+Use this operation to copy cache data between blue and green databases. This is essential for maintaining cache consistency during blue-green deployments.
 
 ```bash
-# Copy all tables and data from blue to green
+# Copy cache data from blue to green
 pnpm db:copy-cache --copyFrom=blue
 
-# Copy all tables and data from green to blue
+# Copy cache data from green to blue
 pnpm db:copy-cache --copyFrom=green
 
 # Using the shorthand parameter
 pnpm db:copy-cache -f blue
 ```
 
-### How Database Copy Works
+### How Cache Data Copy Works
 
 1. The script reads the PostgreSQL connection details from the `DATABASE_URL` environment variable
-2. It determines the source and target databases based on the `copyFrom` parameter
-3. It retrieves a list of all tables in the source database
-4. For each table:
-    - It truncates the target table (removing all existing data)
-    - Copies all data from the source table to the target table
+2. It handles the two specific cache tables: `price_cache` and `metadata_cache`
+3. For each table:
+    - It truncates the target table
+    - Copies all data from the source to the target table
     - Processes data in batches to avoid memory issues with large tables
-5. After completion, the target database is an exact copy of the source database
 
-## Blue-Green Deployment Process
+### Cache Tables
 
-Here's a typical workflow for using this utility in a blue-green deployment:
+The script only copies the following tables, which contain cached data from external services:
 
-```bash
-# Step 1: Ensure both databases exist
-pnpm db:create-databases
+-   `price_cache`: Stores token price information
+-   `metadata_cache`: Stores token metadata
 
-# Step 2: Deploy new version to the inactive environment (e.g., green)
-# (Your deployment steps here)
-
-# Step 3: Copy data from the active environment to the inactive one
-pnpm db:copy-cache --copyFrom=blue
-
-# Step 4: Switch traffic to the newly updated environment
-# (Your traffic switching steps here)
-```
-
-This process allows for zero-downtime deployments by maintaining two parallel database environments.
+All other tables are managed through the regular migration process and are not part of the blue-green deployment cache copying strategy.

--- a/scripts/migrations/package.json
+++ b/scripts/migrations/package.json
@@ -18,6 +18,8 @@
         "clean": "rm -rf dist/",
         "db:cache:migrate": "tsx src/migrateDb.script.ts --migrationsFolder external_services_cache",
         "db:cache:reset": "tsx src/resetDb.script.ts --migrationsFolder external_services_cache",
+        "db:copy-cache": "tsx src/copyCache.script.ts",
+        "db:create-databases": "tsx src/createDatabases.script.ts",
         "db:migrate": "tsx src/migrateDb.script.ts",
         "db:reset": "tsx src/resetDb.script.ts",
         "format": "prettier --check \"{src,test}/**/*.{js,ts,json}\"",
@@ -32,10 +34,12 @@
         "@grants-stack-indexer/shared": "workspace:*",
         "dotenv": "16.4.5",
         "kysely": "0.27.4",
+        "pg": "8.13.0",
         "yargs": "17.7.2",
         "zod": "3.23.8"
     },
     "devDependencies": {
+        "@types/pg": "8.11.10",
         "@types/yargs": "17.0.33",
         "tsx": "4.19.2"
     }

--- a/scripts/migrations/src/constants.ts
+++ b/scripts/migrations/src/constants.ts
@@ -24,7 +24,8 @@ export interface ConnectionDetails {
  */
 export const extractConnectionDetails = (url: string): ConnectionDetails => {
     // Parse DATABASE_URL (format: postgres://user:password@host:port/dbname)
-    const connectionRegex = /postgres:\/\/([^:]+):([^@]+)@([^:]+):([^\/]+)\/.*/;
+    // Allow for different protocol variants: postgre, postgres, postgresql
+    const connectionRegex = /(?:postgre(?:s|sql)?):\/\/([^:]+):([^@]+)@([^:]+):([^\/]+)\/.*/;
     const match = url.match(connectionRegex);
 
     if (!match || match.length < 5) {

--- a/scripts/migrations/src/constants.ts
+++ b/scripts/migrations/src/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared constants for blue-green deployment database operations
+ */
+
+// Constant database names
+export const BLUE_DB = "GitcoinDatalayerBlue";
+export const GREEN_DB = "GitcoinDatalayerGreen";
+
+// These are the only two cache tables we need to handle
+export const CACHE_TABLES = ["price_cache", "metadata_cache"];
+
+/**
+ * Interface for database connection details
+ */
+export interface ConnectionDetails {
+    host: string;
+    port: string;
+    user: string;
+    password: string;
+}
+
+/**
+ * Extract connection details from DATABASE_URL
+ */
+export const extractConnectionDetails = (url: string): ConnectionDetails => {
+    // Parse DATABASE_URL (format: postgres://user:password@host:port/dbname)
+    const connectionRegex = /postgres:\/\/([^:]+):([^@]+)@([^:]+):([^\/]+)\/.*/;
+    const match = url.match(connectionRegex);
+
+    if (!match || match.length < 5) {
+        throw new Error(`Invalid DATABASE_URL format: ${url}`);
+    }
+
+    return {
+        user: match[1] as string,
+        password: match[2] as string,
+        host: match[3] as string,
+        port: match[4] as string,
+    };
+};

--- a/scripts/migrations/src/copyCache.script.ts
+++ b/scripts/migrations/src/copyCache.script.ts
@@ -87,6 +87,12 @@ export const copyTableData = async (
         user,
         password,
         database: targetDb,
+        ssl:
+            process.env.NODE_ENV === "production"
+                ? {
+                      rejectUnauthorized: false,
+                  }
+                : undefined,
         connectionTimeoutMillis: 30000, // Longer timeout for data copy
         idleTimeoutMillis: 10000,
         max: 5,
@@ -99,6 +105,12 @@ export const copyTableData = async (
         user,
         password,
         database: sourceDb,
+        ssl:
+            process.env.NODE_ENV === "production"
+                ? {
+                      rejectUnauthorized: false,
+                  }
+                : undefined,
         connectionTimeoutMillis: 30000,
         idleTimeoutMillis: 10000,
         max: 5,

--- a/scripts/migrations/src/copyCache.script.ts
+++ b/scripts/migrations/src/copyCache.script.ts
@@ -5,20 +5,26 @@ import { hideBin } from "yargs/helpers";
 
 import { Logger, stringify } from "@grants-stack-indexer/shared";
 
-import { BLUE_DB, ConnectionDetails, extractConnectionDetails, GREEN_DB } from "./constants.js";
+import {
+    BLUE_DB,
+    CACHE_TABLES,
+    ConnectionDetails,
+    extractConnectionDetails,
+    GREEN_DB,
+} from "./constants.js";
 import { getDatabaseConfigFromEnv } from "./schemas/index.js";
-
-configDotenv();
 
 const { Pool } = pg;
 
+configDotenv();
+
 /**
- * This script copies all table data between blue and green databases.
+ * This script copies cache data between blue and green databases.
  *
  * It performs the following steps:
  * 1. Loads environment variables from .env file
  * 2. Gets database configuration from environment
- * 3. Copies all tables from source to target database, resetting destination tables first
+ * 3. Copies cache tables from source to target database
  *
  * Environment variables required:
  * - DATABASE_URL: PostgreSQL connection string (used to extract host, port, user, password)
@@ -37,10 +43,6 @@ interface CopyCacheCommandArgs {
 }
 
 // Define interfaces for database query results
-interface TableNameRow {
-    table_name: string;
-}
-
 interface ColumnNameRow {
     column_name: string;
 }
@@ -63,56 +65,11 @@ const parseArguments = (): CopyCacheCommandArgs => {
 };
 
 /**
- * Get all tables in the public schema
- */
-export const getAllTables = async (
-    db: string,
-    connectionDetails: ConnectionDetails,
-): Promise<string[]> => {
-    const logger = Logger.getInstance();
-    const { host, port, user, password } = connectionDetails;
-
-    const pool = new Pool({
-        host,
-        port: parseInt(port, 10),
-        user,
-        password,
-        database: db,
-        ssl:
-            process.env.NODE_ENV === "production"
-                ? {
-                      rejectUnauthorized: false,
-                  }
-                : undefined,
-        connectionTimeoutMillis: 15000,
-        idleTimeoutMillis: 10000,
-        max: 5,
-    });
-
-    try {
-        logger.info(`Getting all tables from database '${db}'...`);
-
-        const result = await pool.query<TableNameRow>(`
-            SELECT table_name 
-            FROM information_schema.tables 
-            WHERE table_schema = 'public' 
-            AND table_type = 'BASE TABLE'
-            ORDER BY table_name
-        `);
-
-        const tables = result.rows.map((row) => row.table_name);
-        logger.info(`Found ${tables.length} tables in database '${db}'`);
-        return tables;
-    } catch (error) {
-        logger.error(`Failed to get tables: ${stringify(error)}`);
-        throw error;
-    } finally {
-        await pool.end();
-    }
-};
-
-/**
  * Copy table data between databases
+ * @param sourceDb - The source database name
+ * @param targetDb - The target database name
+ * @param tableName - The table name to copy
+ * @param connectionDetails - The connection details for the source and target databases
  */
 export const copyTableData = async (
     sourceDb: string,
@@ -188,7 +145,7 @@ export const copyTableData = async (
         const dataResult = await sourcePool.query<DatabaseRow>(`SELECT * FROM "${tableName}"`);
 
         if (dataResult.rows.length === 0) {
-            logger.info(`No data in source table '${tableName}'. Skipping insert.`);
+            logger.info(`No data in source table '${tableName}'. Skipping.`);
             return;
         }
 
@@ -239,9 +196,12 @@ export const copyTableData = async (
 };
 
 /**
- * Copy all tables data from one database to another
+ * Copy cache data from one database to another
+ * @param sourceDb - The source database name
+ * @param targetDb - The target database name
+ * @param connectionDetails - The connection details for the source and target databases
  */
-export const copyAllTableData = async (
+export const copyCacheData = async (
     sourceDb: string,
     targetDb: string,
     connectionDetails: ConnectionDetails,
@@ -249,26 +209,24 @@ export const copyAllTableData = async (
     const logger = Logger.getInstance();
 
     try {
-        logger.info(`Copying all table data from '${sourceDb}' to '${targetDb}'...`);
+        logger.info(`Copying cache data from '${sourceDb}' to '${targetDb}'...`);
 
-        // Get all tables from source database
-        const tables = await getAllTables(sourceDb, connectionDetails);
+        // Log which cache tables we'll copy
+        logger.info(`Using ${CACHE_TABLES.length} cache tables: ${CACHE_TABLES.join(", ")}`);
 
-        if (tables.length === 0) {
-            logger.warn("No tables found in source database. Nothing to copy.");
+        if (CACHE_TABLES.length === 0) {
+            logger.warn("No cache tables defined. Nothing to copy.");
             return;
         }
 
-        logger.info(`Found ${tables.length} tables to copy from source database`);
-
         // Copy each table
-        for (const table of tables) {
+        for (const table of CACHE_TABLES) {
             await copyTableData(sourceDb, targetDb, table, connectionDetails);
         }
 
-        logger.info(`✅ Successfully copied all table data from '${sourceDb}' to '${targetDb}'`);
+        logger.info(`✅ Successfully copied cache data from '${sourceDb}' to '${targetDb}'`);
     } catch (error) {
-        logger.error(`Failed to copy table data: ${stringify(error)}`);
+        logger.error(`Failed to copy cache data: ${stringify(error)}`);
         throw error;
     }
 };
@@ -286,10 +244,10 @@ export const main = async (): Promise<void> => {
     const sourceDb = sourceColor === "blue" ? BLUE_DB : GREEN_DB;
     const targetDb = sourceColor === "blue" ? GREEN_DB : BLUE_DB;
 
-    logger.info(`Copying all table data from ${sourceColor} to ${targetColor}...`);
-    await copyAllTableData(sourceDb, targetDb, connectionDetails);
+    logger.info(`Copying cache data from ${sourceColor} to ${targetColor}...`);
+    await copyCacheData(sourceDb, targetDb, connectionDetails);
 
-    logger.info(`✅ Database ${targetColor} is now an exact copy of ${sourceColor}`);
+    logger.info(`✅ Cache data copied from ${sourceColor} to ${targetColor} successfully`);
 
     process.exit(0);
 };

--- a/scripts/migrations/src/copyCache.script.ts
+++ b/scripts/migrations/src/copyCache.script.ts
@@ -88,7 +88,7 @@ export const copyTableData = async (
         password,
         database: targetDb,
         ssl:
-            process.env.NODE_ENV === "production"
+            process.env.NODE_ENV === "production" || process.env.NODE_ENV === "staging"
                 ? {
                       rejectUnauthorized: false,
                   }
@@ -106,7 +106,7 @@ export const copyTableData = async (
         password,
         database: sourceDb,
         ssl:
-            process.env.NODE_ENV === "production"
+            process.env.NODE_ENV === "production" || process.env.NODE_ENV === "staging"
                 ? {
                       rejectUnauthorized: false,
                   }
@@ -141,48 +141,70 @@ export const copyTableData = async (
             return;
         }
 
-        // Get data from source
-        const dataResult = await sourcePool.query<DatabaseRow>(`SELECT * FROM "${tableName}"`);
+        // Get total count of rows in the source table
+        const countResult = await sourcePool.query<{ count: string }>(
+            `SELECT COUNT(*) as count FROM "${tableName}"`,
+        );
 
-        if (dataResult.rows.length === 0) {
+        if (!countResult.rows[0]) {
+            logger.warn(`Failed to get row count for table '${tableName}'. Skipping.`);
+            return;
+        }
+
+        const totalRows = parseInt(countResult.rows[0].count, 10);
+
+        if (totalRows === 0) {
             logger.info(`No data in source table '${tableName}'. Skipping.`);
             return;
         }
 
-        // Insert data into target in batches
-        const batchSize = 1000;
-        const totalRows = dataResult.rows.length;
+        logger.info(`Found ${totalRows} rows to copy for table '${tableName}'`);
+
+        // Process data in batches to avoid memory issues
+        const fetchBatchSize = 5000; // Number of rows to fetch at once
+        const insertBatchSize = 1000; // Number of rows to insert at once
         let processedRows = 0;
 
-        logger.info(`Copying ${totalRows} rows for table '${tableName}'...`);
+        // Retrieve and process data in batches using LIMIT and OFFSET
+        for (let offset = 0; offset < totalRows; offset += fetchBatchSize) {
+            // Fetch a batch of data
+            const dataResult = await sourcePool.query<DatabaseRow>(
+                `SELECT * FROM "${tableName}" LIMIT $1 OFFSET $2`,
+                [fetchBatchSize, offset],
+            );
 
-        // PostgreSQL has a limit on parameters, so we process in batches
-        for (let i = 0; i < totalRows; i += batchSize) {
-            const batch = dataResult.rows.slice(i, i + batchSize);
+            const batchRows = dataResult.rows;
 
-            // Create a parameterized query for this batch
-            const valueStrings = [];
-            const valueParams = [];
-            let paramIndex = 1;
+            // Process the fetched batch in smaller chunks for insertion
+            for (let i = 0; i < batchRows.length; i += insertBatchSize) {
+                const insertBatch = batchRows.slice(i, i + insertBatchSize);
 
-            for (const row of batch) {
-                const rowParams = [];
-                for (const col of columns) {
-                    rowParams.push(`$${paramIndex++}`);
-                    valueParams.push(row[col]);
+                // Create a parameterized query for this insertion batch
+                const valueStrings = [];
+                const valueParams = [];
+                let paramIndex = 1;
+
+                for (const row of insertBatch) {
+                    const rowParams = [];
+                    for (const col of columns) {
+                        rowParams.push(`$${paramIndex++}`);
+                        valueParams.push(row[col]);
+                    }
+                    valueStrings.push(`(${rowParams.join(", ")})`);
                 }
-                valueStrings.push(`(${rowParams.join(", ")})`);
+
+                const insertQuery = `
+                    INSERT INTO "${tableName}" (${columns.map((c) => `"${c}"`).join(", ")})
+                    VALUES ${valueStrings.join(", ")}
+                `;
+
+                await targetPool.query(insertQuery, valueParams);
+
+                processedRows += insertBatch.length;
+                logger.info(
+                    `Processed ${processedRows} of ${totalRows} rows for table '${tableName}'`,
+                );
             }
-
-            const insertQuery = `
-                INSERT INTO "${tableName}" (${columns.map((c) => `"${c}"`).join(", ")})
-                VALUES ${valueStrings.join(", ")}
-            `;
-
-            await targetPool.query(insertQuery, valueParams);
-
-            processedRows += batch.length;
-            logger.info(`Processed ${processedRows} of ${totalRows} rows for table '${tableName}'`);
         }
 
         logger.info(`Completed copying data for table '${tableName}'`);

--- a/scripts/migrations/src/copyCache.script.ts
+++ b/scripts/migrations/src/copyCache.script.ts
@@ -5,26 +5,20 @@ import { hideBin } from "yargs/helpers";
 
 import { Logger, stringify } from "@grants-stack-indexer/shared";
 
-import {
-    BLUE_DB,
-    CACHE_TABLES,
-    ConnectionDetails,
-    extractConnectionDetails,
-    GREEN_DB,
-} from "./constants.js";
+import { BLUE_DB, ConnectionDetails, extractConnectionDetails, GREEN_DB } from "./constants.js";
 import { getDatabaseConfigFromEnv } from "./schemas/index.js";
-
-const { Pool } = pg;
 
 configDotenv();
 
+const { Pool } = pg;
+
 /**
- * This script copies cache data between blue and green databases.
+ * This script copies all table data between blue and green databases.
  *
  * It performs the following steps:
  * 1. Loads environment variables from .env file
  * 2. Gets database configuration from environment
- * 3. Copies cache tables from source to target database
+ * 3. Copies all tables from source to target database, resetting destination tables first
  *
  * Environment variables required:
  * - DATABASE_URL: PostgreSQL connection string (used to extract host, port, user, password)
@@ -43,6 +37,10 @@ interface CopyCacheCommandArgs {
 }
 
 // Define interfaces for database query results
+interface TableNameRow {
+    table_name: string;
+}
+
 interface ColumnNameRow {
     column_name: string;
 }
@@ -65,11 +63,56 @@ const parseArguments = (): CopyCacheCommandArgs => {
 };
 
 /**
+ * Get all tables in the public schema
+ */
+export const getAllTables = async (
+    db: string,
+    connectionDetails: ConnectionDetails,
+): Promise<string[]> => {
+    const logger = Logger.getInstance();
+    const { host, port, user, password } = connectionDetails;
+
+    const pool = new Pool({
+        host,
+        port: parseInt(port, 10),
+        user,
+        password,
+        database: db,
+        ssl:
+            process.env.NODE_ENV === "production"
+                ? {
+                      rejectUnauthorized: false,
+                  }
+                : undefined,
+        connectionTimeoutMillis: 15000,
+        idleTimeoutMillis: 10000,
+        max: 5,
+    });
+
+    try {
+        logger.info(`Getting all tables from database '${db}'...`);
+
+        const result = await pool.query<TableNameRow>(`
+            SELECT table_name 
+            FROM information_schema.tables 
+            WHERE table_schema = 'public' 
+            AND table_type = 'BASE TABLE'
+            ORDER BY table_name
+        `);
+
+        const tables = result.rows.map((row) => row.table_name);
+        logger.info(`Found ${tables.length} tables in database '${db}'`);
+        return tables;
+    } catch (error) {
+        logger.error(`Failed to get tables: ${stringify(error)}`);
+        throw error;
+    } finally {
+        await pool.end();
+    }
+};
+
+/**
  * Copy table data between databases
- * @param sourceDb - The source database name
- * @param targetDb - The target database name
- * @param tableName - The table name to copy
- * @param connectionDetails - The connection details for the source and target databases
  */
 export const copyTableData = async (
     sourceDb: string,
@@ -145,7 +188,7 @@ export const copyTableData = async (
         const dataResult = await sourcePool.query<DatabaseRow>(`SELECT * FROM "${tableName}"`);
 
         if (dataResult.rows.length === 0) {
-            logger.info(`No data in source table '${tableName}'. Skipping.`);
+            logger.info(`No data in source table '${tableName}'. Skipping insert.`);
             return;
         }
 
@@ -196,12 +239,9 @@ export const copyTableData = async (
 };
 
 /**
- * Copy cache data from one database to another
- * @param sourceDb - The source database name
- * @param targetDb - The target database name
- * @param connectionDetails - The connection details for the source and target databases
+ * Copy all tables data from one database to another
  */
-export const copyCacheData = async (
+export const copyAllTableData = async (
     sourceDb: string,
     targetDb: string,
     connectionDetails: ConnectionDetails,
@@ -209,24 +249,26 @@ export const copyCacheData = async (
     const logger = Logger.getInstance();
 
     try {
-        logger.info(`Copying cache data from '${sourceDb}' to '${targetDb}'...`);
+        logger.info(`Copying all table data from '${sourceDb}' to '${targetDb}'...`);
 
-        // Log which cache tables we'll copy
-        logger.info(`Using ${CACHE_TABLES.length} cache tables: ${CACHE_TABLES.join(", ")}`);
+        // Get all tables from source database
+        const tables = await getAllTables(sourceDb, connectionDetails);
 
-        if (CACHE_TABLES.length === 0) {
-            logger.warn("No cache tables defined. Nothing to copy.");
+        if (tables.length === 0) {
+            logger.warn("No tables found in source database. Nothing to copy.");
             return;
         }
 
+        logger.info(`Found ${tables.length} tables to copy from source database`);
+
         // Copy each table
-        for (const table of CACHE_TABLES) {
+        for (const table of tables) {
             await copyTableData(sourceDb, targetDb, table, connectionDetails);
         }
 
-        logger.info(`✅ Successfully copied cache data from '${sourceDb}' to '${targetDb}'`);
+        logger.info(`✅ Successfully copied all table data from '${sourceDb}' to '${targetDb}'`);
     } catch (error) {
-        logger.error(`Failed to copy cache data: ${stringify(error)}`);
+        logger.error(`Failed to copy table data: ${stringify(error)}`);
         throw error;
     }
 };
@@ -244,10 +286,10 @@ export const main = async (): Promise<void> => {
     const sourceDb = sourceColor === "blue" ? BLUE_DB : GREEN_DB;
     const targetDb = sourceColor === "blue" ? GREEN_DB : BLUE_DB;
 
-    logger.info(`Copying cache data from ${sourceColor} to ${targetColor}...`);
-    await copyCacheData(sourceDb, targetDb, connectionDetails);
+    logger.info(`Copying all table data from ${sourceColor} to ${targetColor}...`);
+    await copyAllTableData(sourceDb, targetDb, connectionDetails);
 
-    logger.info(`✅ Cache data copied from ${sourceColor} to ${targetColor} successfully`);
+    logger.info(`✅ Database ${targetColor} is now an exact copy of ${sourceColor}`);
 
     process.exit(0);
 };

--- a/scripts/migrations/src/copyCache.script.ts
+++ b/scripts/migrations/src/copyCache.script.ts
@@ -1,0 +1,248 @@
+import { configDotenv } from "dotenv";
+import pg from "pg";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { Logger, stringify } from "@grants-stack-indexer/shared";
+
+import {
+    BLUE_DB,
+    CACHE_TABLES,
+    ConnectionDetails,
+    extractConnectionDetails,
+    GREEN_DB,
+} from "./constants.js";
+import { getDatabaseConfigFromEnv } from "./schemas/index.js";
+
+const { Pool } = pg;
+
+configDotenv();
+
+/**
+ * This script copies cache data between blue and green databases.
+ *
+ * It performs the following steps:
+ * 1. Loads environment variables from .env file
+ * 2. Gets database configuration from environment
+ * 3. Copies cache tables from source to target database
+ *
+ * Environment variables required:
+ * - DATABASE_URL: PostgreSQL connection string (used to extract host, port, user, password)
+ *
+ * Script arguments:
+ * - copyFrom: Source database color ('blue' or 'green')
+ */
+
+// Define interfaces for our command arguments
+interface CopyCacheCommandArgs {
+    _: (string | number)[];
+    copyFrom: "blue" | "green";
+    f?: "blue" | "green";
+    $0: string;
+    [key: string]: unknown;
+}
+
+// Define interfaces for database query results
+interface ColumnNameRow {
+    column_name: string;
+}
+
+interface DatabaseRow {
+    [column: string]: unknown;
+}
+
+const parseArguments = (): CopyCacheCommandArgs => {
+    return yargs(hideBin(process.argv))
+        .option("copyFrom", {
+            alias: "f",
+            type: "string",
+            choices: ["blue", "green"],
+            demandOption: true,
+            description: 'Source database color to copy from ("blue" or "green")',
+        })
+        .strict()
+        .parseSync() as CopyCacheCommandArgs;
+};
+
+/**
+ * Copy table data between databases
+ * @param sourceDb - The source database name
+ * @param targetDb - The target database name
+ * @param tableName - The table name to copy
+ * @param connectionDetails - The connection details for the source and target databases
+ */
+export const copyTableData = async (
+    sourceDb: string,
+    targetDb: string,
+    tableName: string,
+    connectionDetails: ConnectionDetails,
+): Promise<void> => {
+    const logger = Logger.getInstance();
+    const { host, port, user, password } = connectionDetails;
+
+    // Connect to the target database
+    const targetPool = new Pool({
+        host,
+        port: parseInt(port, 10),
+        user,
+        password,
+        database: targetDb,
+        ssl: process.env.NODE_ENV === "production" ? true : false,
+        connectionTimeoutMillis: 30000, // Longer timeout for data copy
+        idleTimeoutMillis: 10000,
+        max: 5,
+    });
+
+    // Create a connection to the source database
+    const sourcePool = new Pool({
+        host,
+        port: parseInt(port, 10),
+        user,
+        password,
+        database: sourceDb,
+        ssl: process.env.NODE_ENV === "production" ? true : false,
+        connectionTimeoutMillis: 30000,
+        idleTimeoutMillis: 10000,
+        max: 5,
+    });
+
+    try {
+        logger.info(`Copying data for table '${tableName}' from ${sourceDb} to ${targetDb}...`);
+
+        // First truncate the target table
+        await targetPool.query(`TRUNCATE TABLE "${tableName}" CASCADE`);
+
+        // Get the column names from the source table
+        const columnResult = await sourcePool.query<ColumnNameRow>(
+            `
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+            AND table_name = $1
+            ORDER BY ordinal_position
+        `,
+            [tableName],
+        );
+
+        const columns = columnResult.rows.map((row) => row.column_name);
+
+        if (columns.length === 0) {
+            logger.warn(`No columns found for table '${tableName}'. Skipping.`);
+            return;
+        }
+
+        // Get data from source
+        const dataResult = await sourcePool.query<DatabaseRow>(`SELECT * FROM "${tableName}"`);
+
+        if (dataResult.rows.length === 0) {
+            logger.info(`No data in source table '${tableName}'. Skipping.`);
+            return;
+        }
+
+        // Insert data into target in batches
+        const batchSize = 1000;
+        const totalRows = dataResult.rows.length;
+        let processedRows = 0;
+
+        logger.info(`Copying ${totalRows} rows for table '${tableName}'...`);
+
+        // PostgreSQL has a limit on parameters, so we process in batches
+        for (let i = 0; i < totalRows; i += batchSize) {
+            const batch = dataResult.rows.slice(i, i + batchSize);
+
+            // Create a parameterized query for this batch
+            const valueStrings = [];
+            const valueParams = [];
+            let paramIndex = 1;
+
+            for (const row of batch) {
+                const rowParams = [];
+                for (const col of columns) {
+                    rowParams.push(`$${paramIndex++}`);
+                    valueParams.push(row[col]);
+                }
+                valueStrings.push(`(${rowParams.join(", ")})`);
+            }
+
+            const insertQuery = `
+                INSERT INTO "${tableName}" (${columns.map((c) => `"${c}"`).join(", ")})
+                VALUES ${valueStrings.join(", ")}
+            `;
+
+            await targetPool.query(insertQuery, valueParams);
+
+            processedRows += batch.length;
+            logger.info(`Processed ${processedRows} of ${totalRows} rows for table '${tableName}'`);
+        }
+
+        logger.info(`Completed copying data for table '${tableName}'`);
+    } catch (error) {
+        logger.error(`Failed to copy table data: ${stringify(error)}`);
+        throw error;
+    } finally {
+        await targetPool.end();
+        await sourcePool.end();
+    }
+};
+
+/**
+ * Copy cache data from one database to another
+ * @param sourceDb - The source database name
+ * @param targetDb - The target database name
+ * @param connectionDetails - The connection details for the source and target databases
+ */
+export const copyCacheData = async (
+    sourceDb: string,
+    targetDb: string,
+    connectionDetails: ConnectionDetails,
+): Promise<void> => {
+    const logger = Logger.getInstance();
+
+    try {
+        logger.info(`Copying cache data from '${sourceDb}' to '${targetDb}'...`);
+
+        // Log which cache tables we'll copy
+        logger.info(`Using ${CACHE_TABLES.length} cache tables: ${CACHE_TABLES.join(", ")}`);
+
+        if (CACHE_TABLES.length === 0) {
+            logger.warn("No cache tables defined. Nothing to copy.");
+            return;
+        }
+
+        // Copy each table
+        for (const table of CACHE_TABLES) {
+            await copyTableData(sourceDb, targetDb, table, connectionDetails);
+        }
+
+        logger.info(`✅ Successfully copied cache data from '${sourceDb}' to '${targetDb}'`);
+    } catch (error) {
+        logger.error(`Failed to copy cache data: ${stringify(error)}`);
+        throw error;
+    }
+};
+
+export const main = async (): Promise<void> => {
+    const { DATABASE_URL } = getDatabaseConfigFromEnv();
+    const args = parseArguments();
+    const connectionDetails = extractConnectionDetails(DATABASE_URL);
+
+    const logger = Logger.getInstance();
+
+    const sourceColor = args.copyFrom;
+    const targetColor = sourceColor === "blue" ? "green" : "blue";
+
+    const sourceDb = sourceColor === "blue" ? BLUE_DB : GREEN_DB;
+    const targetDb = sourceColor === "blue" ? GREEN_DB : BLUE_DB;
+
+    logger.info(`Copying cache data from ${sourceColor} to ${targetColor}...`);
+    await copyCacheData(sourceDb, targetDb, connectionDetails);
+
+    logger.info(`✅ Cache data copied from ${sourceColor} to ${targetColor} successfully`);
+
+    process.exit(0);
+};
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/migrations/src/copyCache.script.ts
+++ b/scripts/migrations/src/copyCache.script.ts
@@ -87,7 +87,6 @@ export const copyTableData = async (
         user,
         password,
         database: targetDb,
-        ssl: process.env.NODE_ENV === "production" ? true : false,
         connectionTimeoutMillis: 30000, // Longer timeout for data copy
         idleTimeoutMillis: 10000,
         max: 5,
@@ -100,7 +99,6 @@ export const copyTableData = async (
         user,
         password,
         database: sourceDb,
-        ssl: process.env.NODE_ENV === "production" ? true : false,
         connectionTimeoutMillis: 30000,
         idleTimeoutMillis: 10000,
         max: 5,

--- a/scripts/migrations/src/createDatabases.script.ts
+++ b/scripts/migrations/src/createDatabases.script.ts
@@ -1,0 +1,92 @@
+import { configDotenv } from "dotenv";
+import pg from "pg";
+
+import { Logger, stringify } from "@grants-stack-indexer/shared";
+
+import { BLUE_DB, ConnectionDetails, extractConnectionDetails, GREEN_DB } from "./constants.js";
+import { getDatabaseConfigFromEnv } from "./schemas/index.js";
+
+const { Pool } = pg;
+
+configDotenv();
+
+/**
+ * This script creates the blue and green databases for blue-green deployment strategy.
+ *
+ * It performs the following steps:
+ * 1. Loads environment variables from .env file
+ * 2. Gets database configuration from environment
+ * 3. Creates both blue and green databases if they don't already exist
+ *
+ * Environment variables required:
+ * - DATABASE_URL: PostgreSQL connection string (used to extract host, port, user, password)
+ */
+
+/**
+ * Create a database if it doesn't exist
+ */
+export const createDatabaseIfNotExists = async (
+    dbName: string,
+    connectionDetails: ConnectionDetails,
+): Promise<void> => {
+    const logger = Logger.getInstance();
+    const { host, port, user, password } = connectionDetails;
+
+    // Configure pool with RDS-appropriate settings to connect to postgres db
+    const pool = new Pool({
+        host,
+        port: parseInt(port, 10),
+        user,
+        password,
+        database: "postgres", // Connect to system database
+        ssl: process.env.NODE_ENV === "production" ? true : false, // Enable SSL for production RDS
+        connectionTimeoutMillis: 15000,
+        idleTimeoutMillis: 10000,
+        max: 5,
+    });
+
+    try {
+        // First check if database already exists
+        const checkResult = await pool.query("SELECT 1 FROM pg_database WHERE datname = $1", [
+            dbName,
+        ]);
+
+        if (checkResult.rowCount && checkResult.rowCount > 0) {
+            logger.info(`Database '${dbName}' already exists.`);
+            return;
+        }
+
+        // Execute CREATE DATABASE
+        logger.info(`Creating new database '${dbName}'...`);
+        await pool.query(`CREATE DATABASE "${dbName}" OWNER "${user}"`);
+
+        logger.info(`Database '${dbName}' created successfully.`);
+    } catch (error) {
+        logger.error(`Failed to create database: ${stringify(error)}`);
+        throw error;
+    } finally {
+        // Always close the pool
+        await pool.end();
+    }
+};
+
+export const main = async (): Promise<void> => {
+    const { DATABASE_URL } = getDatabaseConfigFromEnv();
+    const connectionDetails = extractConnectionDetails(DATABASE_URL);
+
+    const logger = Logger.getInstance();
+    logger.info("Creating blue and green databases if they don't exist...");
+
+    // Create both databases if they don't exist
+    await createDatabaseIfNotExists(BLUE_DB, connectionDetails);
+    await createDatabaseIfNotExists(GREEN_DB, connectionDetails);
+
+    logger.info("✅ Database setup completed successfully");
+
+    process.exit(0);
+};
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/migrations/src/createDatabases.script.ts
+++ b/scripts/migrations/src/createDatabases.script.ts
@@ -39,7 +39,6 @@ export const createDatabaseIfNotExists = async (
         user,
         password,
         database: "postgres", // Connect to system database
-        ssl: process.env.NODE_ENV === "production" ? true : false, // Enable SSL for production RDS
         connectionTimeoutMillis: 15000,
         idleTimeoutMillis: 10000,
         max: 5,

--- a/scripts/migrations/src/createDatabases.script.ts
+++ b/scripts/migrations/src/createDatabases.script.ts
@@ -38,7 +38,12 @@ export const createDatabaseIfNotExists = async (
         port: parseInt(port, 10),
         user,
         password,
-        database: "postgres", // Connect to system database
+        ssl:
+            process.env.NODE_ENV === "production"
+                ? {
+                      rejectUnauthorized: false,
+                  }
+                : undefined,
         connectionTimeoutMillis: 15000,
         idleTimeoutMillis: 10000,
         max: 5,

--- a/scripts/migrations/src/createDatabases.script.ts
+++ b/scripts/migrations/src/createDatabases.script.ts
@@ -39,7 +39,7 @@ export const createDatabaseIfNotExists = async (
         user,
         password,
         ssl:
-            process.env.NODE_ENV === "production"
+            process.env.NODE_ENV === "production" || process.env.NODE_ENV === "staging"
                 ? {
                       rejectUnauthorized: false,
                   }


### PR DESCRIPTION
## Description
We add two more scripts on 'scripts/migrations' for creation of Blue and Green databases in Postgres and cache data copying between them

## Checklist before requesting a review

-   [ ] I have conducted a self-review of my code.
-   [ ] I have conducted a QA.
-   [ ] If it is a core feature, I have included comprehensive tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new commands to automate database setup and cache synchronization for blue-green deployment, streamlining database management.

- **Documentation**
  - Provided a detailed guide outlining procedures for managing PostgreSQL databases in a blue-green deployment setup.

- **Chores**
  - Added new scripts for copying cache data and creating databases, enhancing database management capabilities.
  - Updated dependencies to support PostgreSQL operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->