### PR TITLE
feat: add manual relationship in hasura

### DIFF
--- a/scripts/hasura-config/src/index.ts
+++ b/scripts/hasura-config/src/index.ts
@@ -87,6 +87,26 @@ export const virtualArrayRelationships: RelationshipConfig<Tables>[] = [
             },
         },
     },
+    {
+        name: "projects",
+        table: {
+            name: "applications",
+            schema: "public",
+        },
+        source: "default",
+        using: {
+            manual_configuration: {
+                remote_table: {
+                    name: "projects",
+                    schema: "public",
+                },
+                source: "default",
+                column_mapping: {
+                    project_id: "id",
+                },
+            },
+        },
+    },
 ];
 
 async function configureHasura(): Promise<void> {


### PR DESCRIPTION
## Description

We need to add a manual relationship for Applications -> Projects, that emulates a many-to-many on 'projectId'  (we have a Foreign key but is a One-to-Many on projectId+chainId)

This allows us to make queries like:
```
query ApplicationsByCanonicalProject {
  applications {
    id
    chainId
    projects(where: {projectType: {_eq: "canonical"}}) {
      projectType
      id
      name
    }
  }
}

```
where we get the Canonical project/s for an Application
<img width="900" alt="image" src="https://github.com/user-attachments/assets/947b45d9-38e0-4ca2-ad99-543d22c2dff1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced data integration by linking project details with application records, providing a more seamless management experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->