### PR TITLE
fix: decode attestation data while getting metadata cids

### DIFF
--- a/packages/data-flow/src/helpers/index.ts
+++ b/packages/data-flow/src/helpers/index.ts
@@ -1,4 +1,5 @@
 import {
+    decodeAttestedData,
     decodeDGApplicationData,
     decodeDVMDApplicationData,
     decodeDVMDExtendedApplicationData,
@@ -31,6 +32,10 @@ export const getMetadataCidsFromEvents = (
             try {
                 const decoded = decodeDVMDExtendedApplicationData(event.params.data);
                 ids.add(decoded.metadata.pointer);
+            } catch {}
+            try {
+                const decoded = decodeAttestedData(event.params.data);
+                ids.add(decoded.metadataCid);
             } catch (error) {
                 logger.warn("Failed to decode Metadata CID from event data", {
                     error,

--- a/packages/processors/src/external.ts
+++ b/packages/processors/src/external.ts
@@ -17,4 +17,5 @@ export {
     decodeDVMDApplicationData,
     decodeDVMDExtendedApplicationData,
     decodeDGApplicationData,
+    decodeAttestedData,
 } from "./internal.js";


### PR DESCRIPTION
## Description

We were missing the decoding from Attestations when bulk fetching metadata CIDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data processing now includes an additional decoding mechanism to improve how metadata is extracted from events.
	- Expanded external integrations now benefit from the new decoding support for more robust data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->