### PR TITLE
chore: added verbose log level

### DIFF
--- a/apps/processing/test/unit/processing.service.spec.ts
+++ b/apps/processing/test/unit/processing.service.spec.ts
@@ -26,6 +26,7 @@ vi.mock("../../src/services/sharedDependencies.service.js", () => ({
                 info: vi.fn(),
                 error: vi.fn(),
                 debug: vi.fn(),
+                verbose: vi.fn(),
                 warn: vi.fn(),
             },
         })),

--- a/apps/processing/test/unit/sharedDependencies.service.spec.ts
+++ b/apps/processing/test/unit/sharedDependencies.service.spec.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
             info: vi.fn(),
             error: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
             warn: vi.fn(),
         },
     };

--- a/packages/data-flow/test/data-loader/dataLoader.spec.ts
+++ b/packages/data-flow/test/data-loader/dataLoader.spec.ts
@@ -57,6 +57,7 @@ describe("DataLoader", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/data-flow/test/integration/helpers/setup.ts
+++ b/packages/data-flow/test/integration/helpers/setup.ts
@@ -42,7 +42,7 @@ export const createTestOrchestrator = (
         error: vi.fn(),
         warn: vi.fn(),
         debug: vi.fn(),
-        trace: vi.fn(),
+        verbose: vi.fn(),
     };
     const mockIndexerClient = createMockIndexerClient();
     const { eventsRegistry, strategyRegistry } = createMockRegistries(config.strategiesMap);

--- a/packages/data-flow/test/registries/cachedEventRegistry.spec.ts
+++ b/packages/data-flow/test/registries/cachedEventRegistry.spec.ts
@@ -9,6 +9,7 @@ import { InMemoryCachedEventRegistry } from "../../src/registries/event/cachedEv
 describe("InMemoryCachedEventRegistry", () => {
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/data-flow/test/registries/cachedStrategyRegistry.spec.ts
+++ b/packages/data-flow/test/registries/cachedStrategyRegistry.spec.ts
@@ -10,6 +10,7 @@ import { InMemoryCachedStrategyRegistry } from "../../src/registries/strategy/ca
 describe("InMemoryCachedStrategyRegistry", () => {
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/data-flow/test/registries/dbEventRegistry.spec.ts
+++ b/packages/data-flow/test/registries/dbEventRegistry.spec.ts
@@ -12,6 +12,7 @@ import { DatabaseEventRegistry } from "../../src/registries/event/dbEventRegistr
 describe("DatabaseEventRegistry", () => {
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/data-flow/test/registries/dbStrategyRegistry.spec.ts
+++ b/packages/data-flow/test/registries/dbStrategyRegistry.spec.ts
@@ -9,6 +9,7 @@ import { DatabaseStrategyRegistry } from "../../src/registries/strategy/dbStrate
 describe("DatabaseStrategyRegistry", () => {
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/data-flow/test/unit/orchestrator.spec.ts
+++ b/packages/data-flow/test/unit/orchestrator.spec.ts
@@ -73,6 +73,7 @@ describe("Orchestrator", { sequential: true }, () => {
     const mockFetchDelay = 100;
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/data-flow/test/unit/retroactiveProcessor.spec.ts
+++ b/packages/data-flow/test/unit/retroactiveProcessor.spec.ts
@@ -126,6 +126,7 @@ describe("RetroactiveProcessor", () => {
 
         mockLogger = {
             debug: vi.fn(),
+            verbose: vi.fn(),
             error: vi.fn(),
             info: vi.fn(),
             warn: vi.fn(),

--- a/packages/metadata/test/providers/cachingProxy.provider.spec.ts
+++ b/packages/metadata/test/providers/cachingProxy.provider.spec.ts
@@ -19,6 +19,7 @@ describe("CachingMetadataProvider", () => {
 
     const mockLogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
     } as unknown as ILogger;
 
     let provider: CachingMetadataProvider;

--- a/packages/metadata/test/providers/publicGateway.provider.spec.ts
+++ b/packages/metadata/test/providers/publicGateway.provider.spec.ts
@@ -13,6 +13,7 @@ import {
 describe("PublicGatewayProvider", () => {
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/pricing/test/providers/cachingProxy.provider.spec.ts
+++ b/packages/pricing/test/providers/cachingProxy.provider.spec.ts
@@ -35,6 +35,7 @@ describe("CachingPricingProvider", () => {
 
         mockLogger = {
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as ILogger;
 
         provider = new CachingPricingProvider(mockProvider, mockCache, mockLogger);

--- a/packages/pricing/test/providers/coingecko.provider.spec.ts
+++ b/packages/pricing/test/providers/coingecko.provider.spec.ts
@@ -42,6 +42,7 @@ describe("CoingeckoProvider", () => {
     let provider: CoingeckoProvider;
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/allo/allo.processor.spec.ts
+++ b/packages/processors/test/allo/allo.processor.spec.ts
@@ -33,6 +33,7 @@ describe("AlloProcessor", () => {
     let mockRoundRepository: IRoundReadRepository;
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/alloV1ToV2Migration/allo/alloV1ToV2Migration.processor.spec.ts
+++ b/packages/processors/test/alloV1ToV2Migration/allo/alloV1ToV2Migration.processor.spec.ts
@@ -35,6 +35,7 @@ describe("AlloV1ToV2ProfileMigrationProcessor", () => {
     let mockRoundRepository: IRoundReadRepository;
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/gitcoinAttestationNetwork/gitcoinAttestationNetwork.processor.spec.ts
+++ b/packages/processors/test/gitcoinAttestationNetwork/gitcoinAttestationNetwork.processor.spec.ts
@@ -40,6 +40,7 @@ describe("GitcoinAttestationNetworkProcessor", () => {
     let mockApplicationRepository: IApplicationReadRepository;
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/gitcoinAttestationNetwork/handlers/onAttested.handler.spec.ts
+++ b/packages/processors/test/gitcoinAttestationNetwork/handlers/onAttested.handler.spec.ts
@@ -58,6 +58,7 @@ describe("OnAttestedHandler", () => {
         };
         mockLogger = {
             debug: vi.fn(),
+            verbose: vi.fn(),
             error: vi.fn(),
             info: vi.fn(),
             warn: vi.fn(),

--- a/packages/processors/test/registry/handlers/profileCreated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileCreated.handler.spec.ts
@@ -28,6 +28,7 @@ describe("ProfileCreatedHandler", () => {
     const mockedAddress = "0x48f33AE41E1762e1688125C4f1C536B1491dF803";
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/registry/handlers/profileNameUpdated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileNameUpdated.handler.spec.ts
@@ -30,6 +30,7 @@ describe("ProfileNameUpdatedHandler", () => {
         const handler = new ProfileNameUpdatedHandler(mockEvent, 1 as ChainId, {
             logger: {
                 debug: vi.fn(),
+                verbose: vi.fn(),
                 error: vi.fn(),
                 info: vi.fn(),
                 warn: vi.fn(),

--- a/packages/processors/test/registry/handlers/profileOwnerUpdated.handler.spec.ts
+++ b/packages/processors/test/registry/handlers/profileOwnerUpdated.handler.spec.ts
@@ -31,6 +31,7 @@ describe("ProfileOwnerUpdatedHandler", () => {
                 warn: vi.fn(),
                 error: vi.fn(),
                 debug: vi.fn(),
+                verbose: vi.fn(),
             },
         };
 

--- a/packages/processors/test/strategy/common/baseDistributed.handler.spec.ts
+++ b/packages/processors/test/strategy/common/baseDistributed.handler.spec.ts
@@ -22,6 +22,7 @@ describe("BaseDistributedHandler", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/strategy/common/baseDistributionUpdated.handler.spec.ts
+++ b/packages/processors/test/strategy/common/baseDistributionUpdated.handler.spec.ts
@@ -34,6 +34,7 @@ describe("BaseDistributionUpdatedHandler", () => {
             error: vi.fn(),
             info: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as Logger;
     });
 

--- a/packages/processors/test/strategy/common/baseFundsDistributed.handler.spec.ts
+++ b/packages/processors/test/strategy/common/baseFundsDistributed.handler.spec.ts
@@ -43,6 +43,7 @@ describe("BaseFundsDistributedHandler", () => {
             error: vi.fn(),
             info: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as Logger;
     });
 

--- a/packages/processors/test/strategy/common/baseRecipientStatusUpdated.handler.spec.ts
+++ b/packages/processors/test/strategy/common/baseRecipientStatusUpdated.handler.spec.ts
@@ -40,6 +40,7 @@ describe("BaseRecipientStatusUpdatedHandler", () => {
             error: vi.fn(),
             info: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as Logger;
     });
 

--- a/packages/processors/test/strategy/directAllocation/handlers/directAllocated.handler.spec.ts
+++ b/packages/processors/test/strategy/directAllocation/handlers/directAllocated.handler.spec.ts
@@ -51,6 +51,7 @@ describe("DirectAllocatedHandler", () => {
             error: vi.fn(),
             warn: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as ILogger;
     });
 

--- a/packages/processors/test/strategy/directGrantsLite/directGrantsLite.handler.spec.ts
+++ b/packages/processors/test/strategy/directGrantsLite/directGrantsLite.handler.spec.ts
@@ -69,6 +69,7 @@ describe("DirectGrantsLiteStrategyHandler", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/strategy/directGrantsLite/handlers/updatedRegistration.handler.spec.ts
+++ b/packages/processors/test/strategy/directGrantsLite/handlers/updatedRegistration.handler.spec.ts
@@ -54,6 +54,7 @@ describe("DGLiteUpdatedRegistrationHandler", () => {
             error: vi.fn(),
             info: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as Logger;
     });
 

--- a/packages/processors/test/strategy/directGrantsSimple/directGrantsSimple.handler.spec.ts
+++ b/packages/processors/test/strategy/directGrantsSimple/directGrantsSimple.handler.spec.ts
@@ -56,6 +56,7 @@ describe("DirectGrantsSimpleStrategyHandler", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/dvmdDirectTransfer.handler.spec.ts
+++ b/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/dvmdDirectTransfer.handler.spec.ts
@@ -98,6 +98,7 @@ describe("DVMDDirectTransferHandler", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/handlers/updatedRegistration.handler.spec.ts
+++ b/packages/processors/test/strategy/donationVotingMerkleDistributionDirectTransfer/handlers/updatedRegistration.handler.spec.ts
@@ -54,6 +54,7 @@ describe("DVMDUpdatedRegistrationHandler", () => {
             error: vi.fn(),
             info: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as Logger;
     });
 

--- a/packages/processors/test/strategy/easyRetroFunding/easyRetroFunding.handler.spec.ts
+++ b/packages/processors/test/strategy/easyRetroFunding/easyRetroFunding.handler.spec.ts
@@ -75,6 +75,7 @@ describe("EasyRetroFundingStrategyHandler", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/strategy/easyRetroFunding/handlers/updatedRegistration.handler.spec.ts
+++ b/packages/processors/test/strategy/easyRetroFunding/handlers/updatedRegistration.handler.spec.ts
@@ -54,6 +54,7 @@ describe("ERFUpdatedRegistrationHandler", () => {
             error: vi.fn(),
             info: vi.fn(),
             debug: vi.fn(),
+            verbose: vi.fn(),
         } as unknown as Logger;
     });
 

--- a/packages/processors/test/strategy/strategy.processor.spec.ts
+++ b/packages/processors/test/strategy/strategy.processor.spec.ts
@@ -21,6 +21,7 @@ describe("StrategyProcessor", () => {
     let mockRoundRepository: IRoundReadRepository;
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/processors/test/strategy/strategyHandler.factory.spec.ts
+++ b/packages/processors/test/strategy/strategyHandler.factory.spec.ts
@@ -26,6 +26,7 @@ describe("StrategyHandlerFactory", () => {
 
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/shared/src/logger/logger.interface.ts
+++ b/packages/shared/src/logger/logger.interface.ts
@@ -6,4 +6,5 @@ export interface ILogger {
     info: (message: string, context?: Record<string, unknown>) => void;
     warn: (message: string, context?: Record<string, unknown>) => void;
     debug: (message: string, context?: Record<string, unknown>) => void;
+    verbose: (message: string, context?: Record<string, unknown>) => void;
 }

--- a/packages/shared/src/logger/logger.ts
+++ b/packages/shared/src/logger/logger.ts
@@ -3,9 +3,9 @@ import { createLogger, format, transports, Logger as WinstonLogger } from "winst
 import { stringify } from "../internal.js";
 import { ILogger } from "./logger.interface.js";
 
-type LogLevel = "error" | "warn" | "info" | "debug";
+type LogLevel = "error" | "warn" | "info" | "debug" | "verbose";
 
-const validLogLevels: LogLevel[] = ["error", "warn", "info", "debug"];
+const validLogLevels: LogLevel[] = ["error", "warn", "info", "debug", "verbose"];
 
 export class Logger implements ILogger {
     private logger: WinstonLogger;
@@ -79,5 +79,8 @@ export class Logger implements ILogger {
     }
     debug(message: string, context?: Record<string, unknown>): void {
         this.logger.debug(message, context);
+    }
+    verbose(message: string, context?: Record<string, unknown>): void {
+        this.logger.verbose(message, context);
     }
 }

--- a/packages/shared/test/notifier/notifier.factory.spec.ts
+++ b/packages/shared/test/notifier/notifier.factory.spec.ts
@@ -9,6 +9,7 @@ import { SlackNotifier } from "../../src/notifier/slack.notifier.js";
 describe("NotifierFactory", () => {
     const logger: ILogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/packages/shared/test/notifier/slack.notifier.spec.ts
+++ b/packages/shared/test/notifier/slack.notifier.spec.ts
@@ -21,6 +21,7 @@ describe("SlackNotifier", () => {
     beforeEach(() => {
         logger = {
             debug: vi.fn(),
+            verbose: vi.fn(),
             error: vi.fn(),
             info: vi.fn(),
             warn: vi.fn(),

--- a/packages/shared/test/retry/retry.spec.ts
+++ b/packages/shared/test/retry/retry.spec.ts
@@ -8,6 +8,7 @@ describe("RetryHandler", () => {
     let retriableError: RetriableError;
     const mockLogger = {
         debug: vi.fn(),
+        verbose: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),

--- a/scripts/bootstrap/src/metadata.script.ts
+++ b/scripts/bootstrap/src/metadata.script.ts
@@ -112,7 +112,8 @@ const main = async (): Promise<void> => {
         if (flattedEvents.length === 0) {
             hasMoreEvents = false; // No more flattedEvents to process
         } else {
-            cids.push(...getMetadataCidsFromEvents(flattedEvents, { ...console }));
+            const { trace, ...rest } = console;
+            cids.push(...getMetadataCidsFromEvents(flattedEvents, { ...rest, verbose: trace }));
             // Save checkpoint logic here (e.g., save cids or event data)
         }
         console.log("\n");


### PR DESCRIPTION
- added verbose log level -> winston uses log level verbose instead of trace
- modified all test files that mock the logger by adding `verbose` mock
- modified bootstrap script that was adding `{ ...console }` as logger, by mapping `verbose` to `console.trace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new verbose logging level to capture more granular diagnostic messages.
  - Enhanced logging consistency across various components and tests while preserving existing log levels and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->