### PR TITLE
chore: add managedBy terraform tag to all resources

### DIFF
--- a/deployment/environments/production/main.tf
+++ b/deployment/environments/production/main.tf
@@ -10,6 +10,12 @@ terraform {
 
 provider "aws" {
   region = "us-east-2"
+  default_tags {
+    tags = {
+      ManagedBy   = "Terraform"
+      AppName     = "Indexer"
+    }
+  }
 }
 
 

--- a/deployment/environments/staging/main.tf
+++ b/deployment/environments/staging/main.tf
@@ -10,6 +10,12 @@ terraform {
 
 provider "aws" {
   region = "us-east-2"
+  default_tags {
+    tags = {
+      ManagedBy   = "Terraform"
+      AppName     = "Indexer"
+    }
+  }
 }
 
 

--- a/deployment/registry/main.tf
+++ b/deployment/registry/main.tf
@@ -1,5 +1,11 @@
 provider "aws" {
   region = var.AWS_REGION
+  default_tags {
+    tags = {
+      ManagedBy   = "Terraform"
+      AppName     = "Indexer"
+    }
+  }
 }
 
 module "container_registry" {

--- a/deployment/state/main.tf
+++ b/deployment/state/main.tf
@@ -1,5 +1,11 @@
 provider "aws" {
   region = var.AWS_REGION
+  default_tags {
+    tags = {
+      ManagedBy   = "Terraform"
+      AppName     = "Indexer"
+    }
+  }
 }
 data "aws_caller_identity" "current" {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- AWS resources are now automatically assigned standardized metadata tags, ensuring consistent tracking and improved resource management across all deployment environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->