### PR TITLE
chore: add copy-cache command

### DIFF
--- a/scripts/hasura-config/src/index.ts
+++ b/scripts/hasura-config/src/index.ts
@@ -29,6 +29,7 @@ const tables = [
     "attestations",
     "attestation_txns",
     "events_registry",
+    "price_cache",
 ] as const;
 
 type Tables = typeof tables;

--- a/scripts/migrations/README-DB-BLUE-GREEN.md
+++ b/scripts/migrations/README-DB-BLUE-GREEN.md
@@ -43,7 +43,7 @@ pnpm db:copy-cache -f blue
 ### How Cache Data Copy Works
 
 1. The script reads the PostgreSQL connection details from the `DATABASE_URL` environment variable
-2. It handles the two specific cache tables: `price_cache` and `metadata_cache`
+2. It handles the three specific cache tables: `price_cache`, `metadata_cache` and `strategy_timings`
 3. For each table:
     - It truncates the target table
     - Copies all data from the source to the target table
@@ -55,5 +55,6 @@ The script only copies the following tables, which contain cached data from exte
 
 -   `price_cache`: Stores token price information
 -   `metadata_cache`: Stores token metadata
+-   `strategy_timings`: Stores strategy timings (fetched from contract calls)
 
 All other tables are managed through the regular migration process and are not part of the blue-green deployment cache copying strategy.

--- a/scripts/migrations/src/constants.ts
+++ b/scripts/migrations/src/constants.ts
@@ -6,8 +6,8 @@
 export const BLUE_DB = "GitcoinDatalayerBlue";
 export const GREEN_DB = "GitcoinDatalayerGreen";
 
-// These are the only two cache tables we need to handle
-export const CACHE_TABLES = ["price_cache", "metadata_cache"];
+// These are the only three cache tables we need to handle
+export const CACHE_TABLES = ["price_cache", "metadata_cache", "strategy_timings"];
 
 /**
  * Interface for database connection details

--- a/tests/e2e/test/scenarios/baseSetup.spec-e2e.ts
+++ b/tests/e2e/test/scenarios/baseSetup.spec-e2e.ts
@@ -158,7 +158,7 @@ describe("Base Setup", () => {
             // Verify unexpected types don't exist
             const unexpectedTypes = [
                 "metadatacache",
-                "pricecache",
+                "strategy_timings",
                 "processevents",
                 "kyselymigration",
                 "strategiesregistry",


### PR DESCRIPTION
# 🤖 Linear

Merge after 1st reindex is done with strategyTiming cache 

## Description

## Checklist before requesting a review

-   [ ] I have conducted a self-review of my code.
-   [ ] I have conducted a QA.
-   [ ] If it is a core feature, I have included comprehensive tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to include the `strategy_timings` cache table in the blue-green database deployment process.

- **Chores**
  - Added `strategy_timings` to the list of cache tables managed during migration operations.
  - Expanded tracked database tables in Hasura configuration to include `price_cache`.
  - Updated tests to reflect changes in tracked cache tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->